### PR TITLE
feat: 신한 예금주 실명 조회 기능 구현

### DIFF
--- a/Backend/src/main/java/gwangju/ssafy/backend/component/shinhan/ShinhanApiFeignClient.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/component/shinhan/ShinhanApiFeignClient.java
@@ -4,6 +4,7 @@ package gwangju.ssafy.backend.component.shinhan;
 import gwangju.ssafy.backend.component.shinhan.dto.ShinhanBalanceDetailApi;
 import gwangju.ssafy.backend.component.shinhan.dto.ShinhanApiDto;
 import gwangju.ssafy.backend.component.shinhan.dto.ShinhanResponseHeader;
+import gwangju.ssafy.backend.component.shinhan.dto.ShinhanSearchNameApi;
 import gwangju.ssafy.backend.component.shinhan.dto.ShinhanTransactionApi;
 import gwangju.ssafy.backend.config.HeaderConfiguration;
 import org.springframework.cloud.openfeign.FeignClient;
@@ -22,4 +23,7 @@ interface ShinhanApiFeignClient {
 	ShinhanApiDto<ShinhanResponseHeader, ShinhanTransactionApi.Response> getTransactions(
 		@RequestBody ShinhanApiDto<ShinhanApiKey, ShinhanTransactionApi.Request> request);
 
+	@PostMapping("/v1/search/name")
+	ShinhanApiDto<ShinhanResponseHeader, ShinhanSearchNameApi.Response> searchName(
+		@RequestBody ShinhanApiDto<ShinhanApiKey, ShinhanSearchNameApi.Request> request);
 }

--- a/Backend/src/main/java/gwangju/ssafy/backend/component/shinhan/ShinhanBankService.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/component/shinhan/ShinhanBankService.java
@@ -1,6 +1,7 @@
 package gwangju.ssafy.backend.component.shinhan;
 
 
+import gwangju.ssafy.backend.component.shinhan.dto.DepositHolderName;
 import gwangju.ssafy.backend.component.shinhan.dto.TransactionInfo;
 import gwangju.ssafy.backend.component.shinhan.dto.BalanceDetail;
 
@@ -10,5 +11,7 @@ public interface ShinhanBankService {
 	BalanceDetail getBalanceDetail(String accountNumber);
 
 	TransactionInfo getAccountTransaction(String accountNumber);
+
+	DepositHolderName searchDepositHolderName(String depositBankCode, String depositAccountNumber);
 
 }

--- a/Backend/src/main/java/gwangju/ssafy/backend/component/shinhan/ShinhanBankServiceImpl.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/component/shinhan/ShinhanBankServiceImpl.java
@@ -1,5 +1,7 @@
 package gwangju.ssafy.backend.component.shinhan;
 
+import gwangju.ssafy.backend.component.shinhan.dto.DepositHolderName;
+import gwangju.ssafy.backend.component.shinhan.dto.ShinhanSearchNameApi;
 import gwangju.ssafy.backend.component.shinhan.dto.ShinhanTransactionApi;
 import gwangju.ssafy.backend.component.shinhan.dto.TransactionInfo;
 import gwangju.ssafy.backend.component.shinhan.dto.BalanceDetail;
@@ -54,5 +56,26 @@ public class ShinhanBankServiceImpl implements ShinhanBankService {
 		}
 
 		return transactions.getDataBody().toDto();
+	}
+
+	@Override
+	public DepositHolderName searchDepositHolderName(String depositBankCode, String depositAccountNumber) {
+
+		ShinhanApiDto<ShinhanApiKey, ShinhanSearchNameApi.Request> request = ShinhanApiDto.<ShinhanApiKey, ShinhanSearchNameApi.Request>builder()
+			.dataHeader(apiKey)
+			.dataBody(ShinhanSearchNameApi.Request.builder()
+				.입금계좌번호(depositAccountNumber)
+				.입금은행코드(depositBankCode)
+				.build())
+			.build();
+
+		ShinhanApiDto<ShinhanResponseHeader, ShinhanSearchNameApi.Response> name = apiClient.searchName(
+			request);
+
+		if (name.getDataHeader().getSuccessCode().equals(1)) {
+			throw new RuntimeException(name.getDataHeader().getResultCode());
+		}
+
+		return name.getDataBody().toDto();
 	}
 }

--- a/Backend/src/main/java/gwangju/ssafy/backend/component/shinhan/dto/DepositHolderName.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/component/shinhan/dto/DepositHolderName.java
@@ -1,0 +1,18 @@
+package gwangju.ssafy.backend.component.shinhan.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class DepositHolderName {
+
+	private String backCode;
+	private String accountNumber;
+	private String name;
+
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/component/shinhan/dto/ShinhanSearchNameApi.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/component/shinhan/dto/ShinhanSearchNameApi.java
@@ -1,0 +1,35 @@
+package gwangju.ssafy.backend.component.shinhan.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ShinhanSearchNameApi {
+
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	@Builder
+	public static class Request {
+		private String 입금은행코드;
+		private String 입금계좌번호;
+	}
+
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class Response {
+		private String 입금은행코드;
+		private String 입금계좌번호;
+		private String 입금계좌성명;
+
+		public DepositHolderName toDto(){
+			return DepositHolderName.builder()
+				.backCode(this.입금은행코드)
+				.accountNumber(this.입금계좌번호)
+				.name(this.입금계좌성명)
+				.build();
+		}
+	}
+}


### PR DESCRIPTION
**개요**
---

- #6 
- 신한 예금주 실명 조회 기능 구현

**타입**
---

- [x]  feat : 새로운 기능 추가


**작업 사항**
---
- OpenFeign을 이용하여 신한은행 API와 연동하였습니다.
- 은행 코드와 계좌 번호를 입력하면 실명을 조회할 수 있는 기능을 구현하였습니다.


**Others**
---
![image](https://github.com/SSoc-Student-SOCiety/SSoc/assets/87813831/f260eef2-922d-4ff5-a816-013b7fb09621)
![image](https://github.com/SSoc-Student-SOCiety/SSoc/assets/87813831/028746f5-c45d-4177-aa21-ae8c584f35ba)

