### PR TITLE
feat: 그룹 계좌 연동 API 구현

### DIFF
--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/controller/GroupAccountController.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/controller/GroupAccountController.java
@@ -1,0 +1,36 @@
+package gwangju.ssafy.backend.domain.transaction.controller;
+
+import gwangju.ssafy.backend.domain.group.dto.EditGroupInfoRequest;
+import gwangju.ssafy.backend.domain.transaction.dto.RegisterGroupAccountRequest;
+import gwangju.ssafy.backend.domain.transaction.dto.SendAuthCodeRequest;
+import gwangju.ssafy.backend.domain.transaction.service.GroupAccountService;
+import gwangju.ssafy.backend.global.common.dto.Message;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/group/account")
+@RestController
+public class GroupAccountController {
+
+	private final GroupAccountService groupAccountService;
+
+	@PostMapping("/auth/send")
+	public ResponseEntity<Message> sendAuthCode(@RequestBody SendAuthCodeRequest request) {
+		groupAccountService.sendAuthCode(request);
+		return ResponseEntity.ok().body(Message.success());
+	}
+
+	@PostMapping("/register")
+	public ResponseEntity<Message> sendAuthCode(@RequestBody RegisterGroupAccountRequest request) {
+		groupAccountService.registerGroupAccount(request);
+		return ResponseEntity.ok().body(Message.success());
+	}
+
+
+
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/dto/RegisterGroupAccountRequest.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/dto/RegisterGroupAccountRequest.java
@@ -1,0 +1,23 @@
+package gwangju.ssafy.backend.domain.transaction.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+@Setter
+public class RegisterGroupAccountRequest {
+
+	private Long groupId;
+	private Long userId;
+	private String authCode;
+	private String accountNumber;
+	private String bankCode;
+	private String bankName;
+
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/dto/SendAuthCodeRequest.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/dto/SendAuthCodeRequest.java
@@ -1,0 +1,22 @@
+package gwangju.ssafy.backend.domain.transaction.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+@Setter
+public class SendAuthCodeRequest {
+
+	private Long userId;
+	private Long groupId;
+	private String accountNumber;
+	private String bankCode;
+	private String bankName;
+
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/entity/GroupAccount.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/entity/GroupAccount.java
@@ -1,7 +1,11 @@
 package gwangju.ssafy.backend.domain.transaction.entity;
 
 import gwangju.ssafy.backend.domain.group.entity.Group;
+import gwangju.ssafy.backend.global.common.entity.vo.Bank;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.AttributeOverrides;
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -30,10 +34,12 @@ public class GroupAccount {
 	@Column
 	private String number;
 
-	@Column
-	private String bankCode;
+	@Embedded
+	@AttributeOverrides({
+		@AttributeOverride(name = "name", column = @Column(name = "bank_name")),
+		@AttributeOverride(name = "code", column = @Column(name = "bank_code"))
+	})
+	private Bank bank;
 
-	@Column
-	private String bankName;
 
 }

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/entity/GroupAccount.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/entity/GroupAccount.java
@@ -30,4 +30,10 @@ public class GroupAccount {
 	@Column
 	private String number;
 
+	@Column
+	private String bankCode;
+
+	@Column
+	private String bankName;
+
 }

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/entity/Transaction.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/entity/Transaction.java
@@ -1,6 +1,5 @@
 package gwangju.ssafy.backend.domain.transaction.entity;
 
-import gwangju.ssafy.backend.domain.group.entity.Group;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -30,7 +29,7 @@ public class Transaction {
 
 	@ManyToOne(fetch = FetchType.LAZY, optional = false)
 	@JoinColumn
-	private Group group;
+	private GroupAccount groupAccount;
 
 	@Column
 	private LocalDateTime date;

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/repository/TransactionBatchRepositoryImpl.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/repository/TransactionBatchRepositoryImpl.java
@@ -29,7 +29,7 @@ class TransactionBatchRepositoryImpl implements TransactionBatchRepository {
 
 		log.info("===== 거래 내역 배치 JdbcTemplate 실행 =====");
 		String sql =
-			"INSERT INTO TRANSACTIONS (group_id, date, briefs, withdrawal, deposit, detail, balance, category, branch)"
+			"INSERT INTO TRANSACTIONS (group_account_id, date, briefs, withdrawal, deposit, detail, balance, category, branch)"
 				+ "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
 			log.info("===== 저장될 거래 내역 개수 : {} =====", transactions.size());
@@ -37,7 +37,7 @@ class TransactionBatchRepositoryImpl implements TransactionBatchRepository {
 				jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
 					@Override
 					public void setValues(PreparedStatement ps, int i) throws SQLException {
-						ps.setLong(1, transaction.getGroup().getId());
+						ps.setLong(1, transaction.getGroupAccount().getId());
 						ps.setTimestamp(2, Timestamp.valueOf(transaction.getDate()));
 						ps.setString(3, transaction.getBriefs());
 						ps.setLong(4, transaction.getWithdrawal());

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/repository/TransactionRepository.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/repository/TransactionRepository.java
@@ -5,6 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TransactionRepository extends JpaRepository<Transaction, Long>,TransactionBatchRepository {
 
-	int countByGroup_Id(Long groupId);
+	int countByGroupAccount_Id(Long groupAccountId);
 
 }

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/service/GroupAccountService.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/service/GroupAccountService.java
@@ -1,0 +1,13 @@
+package gwangju.ssafy.backend.domain.transaction.service;
+
+import gwangju.ssafy.backend.domain.transaction.dto.RegisterGroupAccountRequest;
+import gwangju.ssafy.backend.domain.transaction.dto.SendAuthCodeRequest;
+
+public interface GroupAccountService {
+
+	void sendAuthCode(SendAuthCodeRequest request);
+
+	void registerGroupAccount(RegisterGroupAccountRequest request);
+
+
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/service/impl/GroupAccountServiceImpl.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/service/impl/GroupAccountServiceImpl.java
@@ -1,0 +1,101 @@
+package gwangju.ssafy.backend.domain.transaction.service.impl;
+
+import gwangju.ssafy.backend.domain.group.entity.Group;
+import gwangju.ssafy.backend.domain.group.entity.GroupMember;
+import gwangju.ssafy.backend.domain.group.entity.enums.GroupMemberRole;
+import gwangju.ssafy.backend.domain.group.repository.GroupMemberRepository;
+import gwangju.ssafy.backend.domain.group.repository.GroupRepository;
+import gwangju.ssafy.backend.domain.transaction.dto.RegisterGroupAccountRequest;
+import gwangju.ssafy.backend.domain.transaction.dto.SendAuthCodeRequest;
+import gwangju.ssafy.backend.domain.transaction.entity.GroupAccount;
+import gwangju.ssafy.backend.domain.transaction.repository.GroupAccountRepository;
+import gwangju.ssafy.backend.domain.transaction.service.GroupAccountService;
+import gwangju.ssafy.backend.global.common.entity.vo.Bank;
+import gwangju.ssafy.backend.global.infra.feign.shinhan.service.ShinhanBankService;
+import gwangju.ssafy.backend.global.utils.AuthCodeGenerator;
+import jakarta.transaction.Transactional;
+import java.time.Duration;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+class GroupAccountServiceImpl implements GroupAccountService {
+
+	private final GroupAccountRepository groupAccountRepository;
+	private final ShinhanBankService shinhanBankService;
+	private final GroupRepository groupRepository;
+	private final GroupMemberRepository groupMemberRepository;
+	private final RedisTemplate<String, String> redisTemplate;
+	private final static String KEY_PREFIX = "registerGroupAccount::";
+
+	@Override
+	public void sendAuthCode(SendAuthCodeRequest request) {
+		validateAuthority(request.getGroupId(), request.getUserId());
+
+		// 인증 코드 생성
+		String authCode = AuthCodeGenerator.generate();
+
+		// Redis에 이미 인증 코드가 있는지 확인
+		if (!getAuthCodeInRedis(KEY_PREFIX + request.getGroupId()).isEmpty()) {
+			throw new RuntimeException("이미 인증코드가 발송되어 있음");
+		}
+
+		// Redis에 인증 코드 저장
+		redisTemplate.opsForValue()
+			.set(KEY_PREFIX + request.getGroupId(), authCode, Duration.ofMinutes(3));
+
+		// 신한 1원 이체 API로 해당 계좌에 인증 코드 발송
+		shinhanBankService.transferAuth(request.getBankCode(), request.getAccountNumber(),
+			authCode);
+	}
+
+	@Override
+	public void registerGroupAccount(RegisterGroupAccountRequest request) {
+		validateAuthority(request.getGroupId(), request.getUserId());
+
+		String key = KEY_PREFIX + request.getGroupId();
+
+		// 인증 코드 검증
+		String authCode = getAuthCodeInRedis(key)
+			.orElseThrow(() -> new RuntimeException("해당 인증 코드가 없음"));
+
+		if (!request.getAuthCode().equals(authCode)) {
+			throw new RuntimeException("인증 코드가 일치하지 않음");
+		}
+
+		// GroupAccount 등록
+		Group group = groupRepository.findById(request.getGroupId())
+			.orElseThrow(() -> new RuntimeException("존재하지 않는 그룹"));
+
+		GroupAccount account = GroupAccount.builder()
+			.group(group)
+			.number(request.getAccountNumber())
+			.bank(new Bank(request.getBankName(), request.getBankCode()))
+			.build();
+
+		//
+		groupAccountRepository.save(account);
+
+		// 레디스에서 키 삭제
+		redisTemplate.delete(key);
+	}
+
+	private void validateAuthority(Long groupId, Long userId) {
+
+		GroupMember member = groupMemberRepository.findByGroupIdAndUserId(groupId, userId)
+			.orElseThrow(() -> new RuntimeException("그룹원이 아님"));
+
+		if (!member.getRole().equals(GroupMemberRole.MANAGER)) {
+			throw new RuntimeException("그룹 관리자가 아님");
+		}
+	}
+
+	private Optional<String> getAuthCodeInRedis(String key) {
+		return Optional.ofNullable(redisTemplate.opsForValue().get(key));
+	}
+
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/global/common/entity/vo/Bank.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/global/common/entity/vo/Bank.java
@@ -1,0 +1,17 @@
+package gwangju.ssafy.backend.global.common.entity.vo;
+
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Embeddable
+public class Bank {
+
+	private String name;
+	private String code;
+
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/global/config/RedisConfig.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/global/config/RedisConfig.java
@@ -1,0 +1,36 @@
+package gwangju.ssafy.backend.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+	@Value("${spring.data.redis.host}")
+	private String host;
+
+	@Value("${spring.data.redis.port}")
+	private int port;
+
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		return new LettuceConnectionFactory(host, port);
+	}
+
+	@Bean
+	public RedisTemplate<String, Object> redisTemplate() {
+		RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setValueSerializer(new StringRedisSerializer());
+		redisTemplate.setConnectionFactory(redisConnectionFactory());
+		return redisTemplate;
+	}
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/jobs/DailyTransactionReader.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/jobs/DailyTransactionReader.java
@@ -42,7 +42,7 @@ public class DailyTransactionReader implements ItemReader<List<Transaction>> {
 
 			List<TransactionInfo.Transaction> transactions = info.getTransactions();
 
-			int cnt = transactionRepository.countByGroup_Id(groupAccount.getGroup().getId());
+			int cnt = transactionRepository.countByGroupAccount_Id(groupAccount.getId());
 			log.info("===== 기존 거래내역 개수 : {} =====", cnt);
 
 			long diff = info.getTransactionCnt() - cnt;
@@ -60,7 +60,7 @@ public class DailyTransactionReader implements ItemReader<List<Transaction>> {
 					.branch(transaction.getBranch())
 					.date(transaction.getDate())
 					.category(transaction.getCategory())
-					.group(groupAccount.getGroup())
+					.groupAccount(groupAccount)
 					.build();
 
 				list.add(result);

--- a/Backend/src/main/java/gwangju/ssafy/backend/global/utils/AuthCodeGenerator.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/global/utils/AuthCodeGenerator.java
@@ -1,0 +1,23 @@
+package gwangju.ssafy.backend.global.utils;
+
+import java.util.Random;
+
+public class AuthCodeGenerator {
+	private static final int CERT_CODE_LENGTH = 8;
+	private static final char[] CHARACTER_TABLE = { 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L',
+		'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X',
+		'Y', 'Z', '1', '2', '3', '4', '5', '6', '7', '8', '9', '0' };
+
+	public static String generate() {
+		Random random = new Random(System.currentTimeMillis());
+
+		StringBuffer buf = new StringBuffer();
+
+		for(int i = 0; i < CERT_CODE_LENGTH; i++) {
+			buf.append(CHARACTER_TABLE[random.nextInt(CHARACTER_TABLE.length)]);
+		}
+
+		return buf.toString();
+	}
+
+}


### PR DESCRIPTION
**개요**

- #16 
- 그룹 계좌 연동 API 구현

**타입**

- [x]  feat : 새로운 기능 추가


**작업 사항**
- 그룹 매니저가 계좌 연동 요청 시, 해당 계좌로 1원 이체 인증 코드를 보냅니다.
- 3분 안에 해당 코드를 통해 계좌 등록을 요청하면 레디스에 저장된 인증 코드 값과 비교 후 계좌를 등록합니다.