### PR TITLE
feat: 그룹 거래내역 비고 수정 API 구현

### DIFF
--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/controller/TransactionController.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/controller/TransactionController.java
@@ -1,0 +1,26 @@
+package gwangju.ssafy.backend.domain.transaction.controller;
+
+import gwangju.ssafy.backend.domain.transaction.dto.EditTransactionNoteRequest;
+import gwangju.ssafy.backend.domain.transaction.service.TransactionService;
+import gwangju.ssafy.backend.global.common.dto.Message;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/group/transaction")
+@RestController
+public class TransactionController {
+
+	private final TransactionService transactionService;
+
+	@PostMapping("/edit")
+	public ResponseEntity<Message> editNote(@RequestBody EditTransactionNoteRequest request) {
+		transactionService.editNote(request);
+		return ResponseEntity.ok().body(Message.success());
+	}
+
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/dto/EditTransactionNoteRequest.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/dto/EditTransactionNoteRequest.java
@@ -1,0 +1,21 @@
+package gwangju.ssafy.backend.domain.transaction.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+@Setter
+public class EditTransactionNoteRequest {
+
+	private Long userId;
+	private Long transactionId;
+	private Long groupAccountId;
+	private String note;
+
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/entity/Transaction.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/entity/Transaction.java
@@ -58,4 +58,9 @@ public class Transaction {
 	@Column
 	private String note;
 
+
+	public void changeNote(String note) {
+		this.note = note;
+	}
+
 }

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/service/TransactionService.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/service/TransactionService.java
@@ -1,0 +1,8 @@
+package gwangju.ssafy.backend.domain.transaction.service;
+
+import gwangju.ssafy.backend.domain.transaction.dto.EditTransactionNoteRequest;
+
+public interface TransactionService {
+
+	void editNote(EditTransactionNoteRequest request);
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/service/impl/TransactionServiceImpl.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/service/impl/TransactionServiceImpl.java
@@ -1,0 +1,46 @@
+package gwangju.ssafy.backend.domain.transaction.service.impl;
+
+import gwangju.ssafy.backend.domain.group.entity.GroupMember;
+import gwangju.ssafy.backend.domain.group.entity.enums.GroupMemberRole;
+import gwangju.ssafy.backend.domain.group.repository.GroupMemberRepository;
+import gwangju.ssafy.backend.domain.transaction.dto.EditTransactionNoteRequest;
+import gwangju.ssafy.backend.domain.transaction.entity.GroupAccount;
+import gwangju.ssafy.backend.domain.transaction.entity.Transaction;
+import gwangju.ssafy.backend.domain.transaction.repository.GroupAccountRepository;
+import gwangju.ssafy.backend.domain.transaction.repository.TransactionRepository;
+import gwangju.ssafy.backend.domain.transaction.service.TransactionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class TransactionServiceImpl implements TransactionService {
+
+	private final TransactionRepository transactionRepository;
+	private final GroupAccountRepository groupAccountRepository;
+	private final GroupMemberRepository groupMemberRepository;
+
+	@Override
+	public void editNote(EditTransactionNoteRequest request) {
+
+		Transaction transaction = transactionRepository.findById(request.getTransactionId())
+			.orElseThrow(() -> new RuntimeException("없는 거래내역"));
+
+		// 그룹 계좌 확인
+		GroupAccount account = groupAccountRepository.findById(request.getGroupAccountId())
+			.orElseThrow((() -> new RuntimeException("존재하지 않는 그룹계좌")));
+
+		// 권한 확인
+		GroupMember member = groupMemberRepository.findByGroupIdAndUserId(
+				account.getGroup().getId(), request.getUserId())
+			.orElseThrow(() -> new RuntimeException("그룹 멤버가 아님"));
+
+		if (!GroupMemberRole.MANAGER.equals(member.getRole())) {
+			throw new RuntimeException("그룹 매니저가 아님");
+		}
+
+		transaction.changeNote(request.getNote());
+	}
+}


### PR DESCRIPTION
**개요**

- #16
- 거래내역 비고 수정 API 구현

**타입**

- [x]  feat : 새로운 기능 추가


**작업 사항**
- 그룹 매니저가 그룹 거래 내역의 비고를 수정할 수 있는 API를 구현했습니다.
- 비고 외에는 수정이 불가합니다.