### PR TITLE
feat: 그룹 검색 API 구현

### DIFF
--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/group/controller/GroupController.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/group/controller/GroupController.java
@@ -1,8 +1,11 @@
 package gwangju.ssafy.backend.domain.group.controller;
 
+import gwangju.ssafy.backend.domain.group.dto.GroupSearchCond;
+import gwangju.ssafy.backend.domain.group.dto.GroupSimpleInfo;
 import gwangju.ssafy.backend.global.common.dto.Message;
 import gwangju.ssafy.backend.domain.group.dto.EditGroupInfoRequest;
 import gwangju.ssafy.backend.domain.group.service.GroupService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -22,4 +25,10 @@ public class GroupController {
 		groupService.editGroupInfo(request);
 		return ResponseEntity.ok().body(Message.success());
 	}
+
+	@PostMapping
+	public ResponseEntity<Message> searchGroup(@RequestBody GroupSearchCond cond) {
+		return ResponseEntity.ok().body(Message.success(groupService.searchGroup(cond)));
+	}
+	
 }

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/group/dto/CreateGroupRequest.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/group/dto/CreateGroupRequest.java
@@ -1,6 +1,8 @@
 package gwangju.ssafy.backend.domain.group.dto;
 
 
+import gwangju.ssafy.backend.domain.group.entity.enums.GroupCategory;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,6 +18,8 @@ public class CreateGroupRequest {
 
 	private Long userId;
 	private Long schoolId;
+	@NotNull
+	private GroupCategory category;
 	private String name;
 	
 }

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/group/dto/GroupSearchCond.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/group/dto/GroupSearchCond.java
@@ -1,0 +1,35 @@
+package gwangju.ssafy.backend.domain.group.dto;
+
+import gwangju.ssafy.backend.domain.group.entity.enums.GroupCategory;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class GroupSearchCond {
+
+	private String word;
+	private GroupCategory category;
+
+
+	/*  반환 size - 필수
+	 * */
+	@NotNull
+	@Min(1)
+	@Max(100)
+	private Long limit;
+
+	/*  페이지 번호 - option - default 0
+	 * */
+	private long pageNumber;
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/group/dto/GroupSimpleInfo.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/group/dto/GroupSimpleInfo.java
@@ -1,0 +1,23 @@
+package gwangju.ssafy.backend.domain.group.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+@Setter
+public class GroupSimpleInfo {
+
+	private Long groupId;
+	private String name;
+	private String aboutUs;
+	private String school;
+
+
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/group/entity/Group.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/group/entity/Group.java
@@ -4,6 +4,7 @@ package gwangju.ssafy.backend.domain.group.entity;
 import gwangju.ssafy.backend.domain.group.entity.enums.GroupCategory;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -38,7 +39,7 @@ public class Group {
 	@Column
 	private String name;
 
-	@Enumerated
+	@Enumerated(EnumType.STRING)
 	private GroupCategory category;
 
 	@Column

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/group/entity/Group.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/group/entity/Group.java
@@ -1,8 +1,10 @@
 package gwangju.ssafy.backend.domain.group.entity;
 
 
+import gwangju.ssafy.backend.domain.group.entity.enums.GroupCategory;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -36,8 +38,8 @@ public class Group {
 	@Column
 	private String name;
 
-	@Column
-	private String category;
+	@Enumerated
+	private GroupCategory category;
 
 	@Column
 	private String aboutUs;
@@ -55,9 +57,8 @@ public class Group {
 		this.isActive = false;
 	}
 
-	public void editInfo(String name, String category, String aboutUs, String introduce,String thumbnail) {
+	public void editInfo(String name, String aboutUs, String introduce,String thumbnail) {
 		this.name = name;
-		this.category = category;
 		this.aboutUs = aboutUs;
 		this.introduce = introduce;
 		this.thumbnail = thumbnail;

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/group/entity/enums/GroupCategory.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/group/entity/enums/GroupCategory.java
@@ -1,0 +1,23 @@
+package gwangju.ssafy.backend.domain.group.entity.enums;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum GroupCategory {
+	COUNCIL, CLUB;
+
+	@JsonCreator
+	public static GroupCategory from(String value) {
+		for (GroupCategory groupCategory : GroupCategory.values()) {
+			if (groupCategory.name().equals(value)) {
+				return groupCategory;
+			}
+		}
+		return null;
+	}
+
+	@JsonValue
+	public String getValue() {
+		return this.name();
+	}
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/group/repository/GroupRepository.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/group/repository/GroupRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface GroupRepository extends JpaRepository<Group, Long> {
+public interface GroupRepository extends JpaRepository<Group, Long>,QueryDslGroupRepository {
 
 	Optional<Group> findByIdAndIsActiveIsTrue(Long id);
 

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/group/repository/QueryDslGroupRepository.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/group/repository/QueryDslGroupRepository.java
@@ -1,0 +1,12 @@
+package gwangju.ssafy.backend.domain.group.repository;
+
+import gwangju.ssafy.backend.domain.group.dto.GroupSearchCond;
+import gwangju.ssafy.backend.domain.group.dto.GroupSimpleInfo;
+import java.util.List;
+
+public interface QueryDslGroupRepository {
+
+	// 그룹 필터링 및 페이징 조회
+	public List<GroupSimpleInfo> findAllBySearchCond(GroupSearchCond cond);
+
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/group/repository/impl/QueryDslGroupRepositoryImpl.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/group/repository/impl/QueryDslGroupRepositoryImpl.java
@@ -1,0 +1,67 @@
+package gwangju.ssafy.backend.domain.group.repository.impl;
+
+import static gwangju.ssafy.backend.domain.group.entity.QGroup.group;
+import static gwangju.ssafy.backend.domain.group.entity.QSchool.school;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import gwangju.ssafy.backend.domain.group.dto.GroupSearchCond;
+import gwangju.ssafy.backend.domain.group.dto.GroupSimpleInfo;
+import gwangju.ssafy.backend.domain.group.entity.enums.GroupCategory;
+import gwangju.ssafy.backend.domain.group.repository.QueryDslGroupRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class QueryDslGroupRepositoryImpl implements QueryDslGroupRepository {
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	@Override
+	public List<GroupSimpleInfo> findAllBySearchCond(GroupSearchCond cond) {
+		return jpaQueryFactory
+			.select(Projections.fields(GroupSimpleInfo.class,
+					group.id.as("groupId"),
+				group.name.as("name"),
+				group.aboutUs.as("aboutUs"),
+				school.name.as("school")
+				))
+			.from(group)
+			.innerJoin(group.school, school)
+			.where(searchNameOrAboutUs(cond))
+			.limit(cond.getLimit())
+			.offset(cond.getPageNumber() * cond.getLimit())
+			.fetch();
+	}
+
+	private BooleanExpression filterGroupCategory(GroupCategory category) {
+		return category == null ? null
+			: group.category.eq(category);
+	}
+
+	private BooleanExpression searchName(String name) {
+		return name == null ? null
+			: group.name.contains(name);
+	}
+
+	private BooleanExpression searchAboutUs(String aboutUs) {
+		return aboutUs == null ? null
+			: group.aboutUs.contains(aboutUs);
+	}
+
+	private BooleanExpression searchSchool(String schoolName) {
+		return school == null ? null
+			: school.name.contains(schoolName);
+	}
+
+	private BooleanBuilder searchNameOrAboutUs(GroupSearchCond cond) {
+		return new BooleanBuilder()
+			.and(filterGroupCategory(cond.getCategory()))
+			.and(searchName(cond.getWord()).or(searchAboutUs(cond.getWord())).or(searchSchool(cond.getWord())));
+	}
+
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/group/repository/impl/QueryDslGroupRepositoryImpl.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/group/repository/impl/QueryDslGroupRepositoryImpl.java
@@ -32,7 +32,7 @@ public class QueryDslGroupRepositoryImpl implements QueryDslGroupRepository {
 				))
 			.from(group)
 			.innerJoin(group.school, school)
-			.where(searchNameOrAboutUs(cond).and(group.isActive.eq(true)))
+			.where(searchCond(cond))
 			.limit(cond.getLimit())
 			.offset(cond.getPageNumber() * cond.getLimit())
 			.fetch();
@@ -58,8 +58,9 @@ public class QueryDslGroupRepositoryImpl implements QueryDslGroupRepository {
 			: school.name.contains(schoolName);
 	}
 
-	private BooleanBuilder searchNameOrAboutUs(GroupSearchCond cond) {
+	private BooleanBuilder searchCond(GroupSearchCond cond) {
 		return new BooleanBuilder()
+			.and(group.isActive.eq(true))
 			.and(filterGroupCategory(cond.getCategory()))
 			.and(searchName(cond.getWord()).or(searchAboutUs(cond.getWord())).or(searchSchool(cond.getWord())));
 	}

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/group/repository/impl/QueryDslGroupRepositoryImpl.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/group/repository/impl/QueryDslGroupRepositoryImpl.java
@@ -32,7 +32,7 @@ public class QueryDslGroupRepositoryImpl implements QueryDslGroupRepository {
 				))
 			.from(group)
 			.innerJoin(group.school, school)
-			.where(searchNameOrAboutUs(cond))
+			.where(searchNameOrAboutUs(cond).and(group.isActive.eq(true)))
 			.limit(cond.getLimit())
 			.offset(cond.getPageNumber() * cond.getLimit())
 			.fetch();

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/group/service/GroupService.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/group/service/GroupService.java
@@ -2,6 +2,9 @@ package gwangju.ssafy.backend.domain.group.service;
 
 import gwangju.ssafy.backend.domain.group.dto.CreateGroupRequest;
 import gwangju.ssafy.backend.domain.group.dto.EditGroupInfoRequest;
+import gwangju.ssafy.backend.domain.group.dto.GroupSearchCond;
+import gwangju.ssafy.backend.domain.group.dto.GroupSimpleInfo;
+import java.util.List;
 
 public interface GroupService {
 
@@ -10,4 +13,6 @@ public interface GroupService {
 	void inactiveGroup(Long groupId);
 
 	void editGroupInfo(EditGroupInfoRequest request);
+
+	List<GroupSimpleInfo> searchGroup(GroupSearchCond cond);
 }

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/group/service/impl/GroupServiceImpl.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/group/service/impl/GroupServiceImpl.java
@@ -35,6 +35,7 @@ class GroupServiceImpl implements GroupService {
 		Group group = Group.builder()
 			.school(school)
 			.name(request.getName())
+			.category(request.getCategory())
 			.isActive(true)
 			.build();
 
@@ -65,7 +66,7 @@ class GroupServiceImpl implements GroupService {
 		Group group = groupRepository.findByIdAndIsActiveIsTrue(member.getGroup().getId())
 			.orElseThrow(() -> new RuntimeException("존재하지 않는 그룹"));
 
-		group.editInfo(request.getName(), request.getCategory(), request.getAboutUs(),
+		group.editInfo(request.getName(),  request.getAboutUs(),
 			request.getIntroduce(),request.getThumbnail());
 
 	}

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/group/service/impl/GroupServiceImpl.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/group/service/impl/GroupServiceImpl.java
@@ -2,6 +2,8 @@ package gwangju.ssafy.backend.domain.group.service.impl;
 
 import gwangju.ssafy.backend.domain.group.dto.CreateGroupRequest;
 import gwangju.ssafy.backend.domain.group.dto.EditGroupInfoRequest;
+import gwangju.ssafy.backend.domain.group.dto.GroupSearchCond;
+import gwangju.ssafy.backend.domain.group.dto.GroupSimpleInfo;
 import gwangju.ssafy.backend.domain.group.entity.Group;
 import gwangju.ssafy.backend.domain.group.entity.GroupMember;
 import gwangju.ssafy.backend.domain.group.entity.School;
@@ -12,6 +14,7 @@ import gwangju.ssafy.backend.domain.group.repository.SchoolRepository;
 import gwangju.ssafy.backend.domain.group.service.GroupMemberService;
 import gwangju.ssafy.backend.domain.group.service.GroupService;
 import jakarta.transaction.Transactional;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -69,6 +72,11 @@ class GroupServiceImpl implements GroupService {
 		group.editInfo(request.getName(),  request.getAboutUs(),
 			request.getIntroduce(),request.getThumbnail());
 
+	}
+
+	@Override
+	public List<GroupSimpleInfo> searchGroup(GroupSearchCond cond) {
+		return groupRepository.findAllBySearchCond(cond);
 	}
 
 }

--- a/Backend/src/main/java/gwangju/ssafy/backend/global/config/QueryDslConfig.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/global/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package gwangju.ssafy.backend.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(entityManager);
+	}
+}


### PR DESCRIPTION
**개요**

- #28 
- 그룹 조회 API 구현

**타입**

- [x]  feat : 새로운 기능 추가


**작업 사항**
- 전체 그룹을 조회하는 API를 구현했습니다.
- 요청 시, 검색 키워드, 카테고리, 가져올 데이터 수, 페이징 번호 를 입력해주면 됩니다.