### PR TITLE
feat: 가입 그룹 조회 API 구현

### DIFF
--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/group/controller/GroupController.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/group/controller/GroupController.java
@@ -2,6 +2,7 @@ package gwangju.ssafy.backend.domain.group.controller;
 
 import gwangju.ssafy.backend.domain.group.dto.GroupSearchCond;
 import gwangju.ssafy.backend.domain.group.dto.GroupSimpleInfo;
+import gwangju.ssafy.backend.domain.group.dto.MyGroupSearchCond;
 import gwangju.ssafy.backend.global.common.dto.Message;
 import gwangju.ssafy.backend.domain.group.dto.EditGroupInfoRequest;
 import gwangju.ssafy.backend.domain.group.service.GroupService;
@@ -27,8 +28,13 @@ public class GroupController {
 	}
 
 	@PostMapping
-	public ResponseEntity<Message> searchGroup(@RequestBody GroupSearchCond cond) {
+	public ResponseEntity<Message<List<GroupSimpleInfo>>> searchGroup(@RequestBody GroupSearchCond cond) {
 		return ResponseEntity.ok().body(Message.success(groupService.searchGroup(cond)));
+	}
+
+	@PostMapping("/my")
+	public ResponseEntity<Message> searchMyGroup(@RequestBody MyGroupSearchCond cond) {
+		return ResponseEntity.ok().body(Message.success(groupService.searchMyGroup(cond)));
 	}
 	
 }

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/group/dto/MyGroupSearchCond.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/group/dto/MyGroupSearchCond.java
@@ -1,0 +1,30 @@
+package gwangju.ssafy.backend.domain.group.dto;
+
+import gwangju.ssafy.backend.domain.group.entity.enums.GroupCategory;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class MyGroupSearchCond {
+
+	private String word;
+	private GroupCategory category;
+	private Long userId;
+
+	@NotNull
+	@Min(1)
+	@Max(100)
+	private Long limit;
+	private long pageNumber;
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/group/repository/QueryDslGroupRepository.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/group/repository/QueryDslGroupRepository.java
@@ -2,11 +2,13 @@ package gwangju.ssafy.backend.domain.group.repository;
 
 import gwangju.ssafy.backend.domain.group.dto.GroupSearchCond;
 import gwangju.ssafy.backend.domain.group.dto.GroupSimpleInfo;
+import gwangju.ssafy.backend.domain.group.dto.MyGroupSearchCond;
 import java.util.List;
 
 public interface QueryDslGroupRepository {
 
 	// 그룹 필터링 및 페이징 조회
-	public List<GroupSimpleInfo> findAllBySearchCond(GroupSearchCond cond);
+	List<GroupSimpleInfo> findAllBySearchCond(GroupSearchCond cond);
+	List<GroupSimpleInfo> findMyGroups(MyGroupSearchCond cond);
 
 }

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/group/service/GroupService.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/group/service/GroupService.java
@@ -4,6 +4,7 @@ import gwangju.ssafy.backend.domain.group.dto.CreateGroupRequest;
 import gwangju.ssafy.backend.domain.group.dto.EditGroupInfoRequest;
 import gwangju.ssafy.backend.domain.group.dto.GroupSearchCond;
 import gwangju.ssafy.backend.domain.group.dto.GroupSimpleInfo;
+import gwangju.ssafy.backend.domain.group.dto.MyGroupSearchCond;
 import java.util.List;
 
 public interface GroupService {
@@ -15,4 +16,5 @@ public interface GroupService {
 	void editGroupInfo(EditGroupInfoRequest request);
 
 	List<GroupSimpleInfo> searchGroup(GroupSearchCond cond);
+	List<GroupSimpleInfo> searchMyGroup(MyGroupSearchCond cond);
 }

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/group/service/impl/GroupServiceImpl.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/group/service/impl/GroupServiceImpl.java
@@ -4,6 +4,7 @@ import gwangju.ssafy.backend.domain.group.dto.CreateGroupRequest;
 import gwangju.ssafy.backend.domain.group.dto.EditGroupInfoRequest;
 import gwangju.ssafy.backend.domain.group.dto.GroupSearchCond;
 import gwangju.ssafy.backend.domain.group.dto.GroupSimpleInfo;
+import gwangju.ssafy.backend.domain.group.dto.MyGroupSearchCond;
 import gwangju.ssafy.backend.domain.group.entity.Group;
 import gwangju.ssafy.backend.domain.group.entity.GroupMember;
 import gwangju.ssafy.backend.domain.group.entity.School;
@@ -77,6 +78,11 @@ class GroupServiceImpl implements GroupService {
 	@Override
 	public List<GroupSimpleInfo> searchGroup(GroupSearchCond cond) {
 		return groupRepository.findAllBySearchCond(cond);
+	}
+
+	@Override
+	public List<GroupSimpleInfo> searchMyGroup(MyGroupSearchCond cond) {
+		return groupRepository.findMyGroups(cond);
 	}
 
 }


### PR DESCRIPTION
**개요**

- #28 
- 가입 그룹 조회 API 구현

**타입**

- [x]  feat : 새로운 기능 추가


**작업 사항**
- 가입 그룹을 조회하는 API를 구현했습니다.
- 요청 시, 검색 키워드, 카테고리, 가져올 데이터 수, 페이징 번호 를 입력해주면 됩니다.