### PR TITLE
feat: group detail bottom tab 구현(#61) 

### DIFF
--- a/SSoc-Client/src/hooks/useScrollEvnet.js
+++ b/SSoc-Client/src/hooks/useScrollEvnet.js
@@ -17,11 +17,10 @@ export const useScrollEvent = () => {
 
   const onScroll = (e) => {
     const y = e.nativeEvent.contentOffset.y;
-    const dy = y - scrollStartRef.current;
+
     scrollStartRef.current = y; // Update scrollStartRef
 
     headerAnim.setValue(y);
-    console.log(headerAnim);
   };
 
   return { onScrollEndDrag, onScrollBeginDrag, onScroll, headerAnim };

--- a/SSoc-Client/src/modules/StackHeader.js
+++ b/SSoc-Client/src/modules/StackHeader.js
@@ -2,20 +2,16 @@ import { Header } from "../components/header/Header";
 import React, { useCallback } from "react";
 import { useNavigation } from "@react-navigation/native";
 
-
-
 export const StackHeader = (props) => {
   const navigation = useNavigation();
   //to-do 뒤로가기 구현하기
   //   const navigation = useNavigation();
   const onPressBack = useCallback(() => {
-    console.log("go back button test ");
     navigation.goBack();
   }, []);
 
   //to-do setting 화면가기 구현하기
   const onPressSetting = useCallback(() => {
-    console.log("setting butotn test");
     navigation.navigate("SettingScreen");
   }, []);
 

--- a/SSoc-Client/src/navigations/GroupDetailNavigations/GroupDetailBottomTabNavigation.js
+++ b/SSoc-Client/src/navigations/GroupDetailNavigations/GroupDetailBottomTabNavigation.js
@@ -1,0 +1,45 @@
+import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
+import React from "react";
+
+import { BoardListScreen } from "../../screens/GroupDetailBottomTabs/Board/BoardListScreen";
+import { BookingScreen } from "../../screens/GroupDetailBottomTabs/Booking/BookingScreen";
+import { ScheduleScreen } from "../../screens/GroupDetailBottomTabs/Schedule/ScheduleScreen";
+import { SettlementScreen } from "../../screens/GroupDetailBottomTabs/Settlement/SettlementScreen";
+
+import { TabIcon } from "../../components/Icons/TabIcon";
+const Tabs = createBottomTabNavigator();
+
+export const GroupDetailBottomTabNavigation = () => {
+  return (
+    <Tabs.Navigator
+      screenOptions={({ route }) => ({
+        headerShown: false,
+        tabBarIcon: ({ focused, color, size }) => {
+          const getIconName = () => {
+            if (route.name === "게시판") {
+              return "brush";
+            }
+            if (route.name === "결산안") {
+              return "analytics";
+            }
+            if (route.name == "일정") {
+              return "calendar";
+            }
+            if (route.name == "물품 예약") {
+              return "cart";
+            }
+          };
+          const iconName = getIconName();
+          return (
+            <TabIcon iconName={iconName} iconColor={focused ? color : "gray"} />
+          );
+        },
+      })}
+    >
+      <Tabs.Screen name="게시판" component={BoardListScreen}></Tabs.Screen>
+      <Tabs.Screen name="결산안" component={SettlementScreen}></Tabs.Screen>
+      <Tabs.Screen name="일정" component={ScheduleScreen}></Tabs.Screen>
+      <Tabs.Screen name="물품 예약" component={BookingScreen}></Tabs.Screen>
+    </Tabs.Navigator>
+  );
+};

--- a/SSoc-Client/src/navigations/GroupDetailNavigations/GroupDetailStackNavigation.js
+++ b/SSoc-Client/src/navigations/GroupDetailNavigations/GroupDetailStackNavigation.js
@@ -1,0 +1,21 @@
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import { GroupDetailBottomTabNavigation } from "./GroupDetailBottomTabNavigation";
+
+const Stack = createNativeStackNavigator();
+export const GroupDetailStackNavigation = ({ route }) => {
+  const { tabName } = route.params;
+  console.log(tabName);
+  return (
+    <Stack.Navigator
+      screenOptions={{
+        headerShown: false,
+      }}
+    >
+      <Stack.Screen
+        name="GroupDetailBottomTab"
+        component={GroupDetailBottomTabNavigation}
+        options={{ tabName: tabName }}
+      />
+    </Stack.Navigator>
+  );
+};

--- a/SSoc-Client/src/navigations/MainNavigations/MainBottomTabNavigation.js
+++ b/SSoc-Client/src/navigations/MainNavigations/MainBottomTabNavigation.js
@@ -1,42 +1,43 @@
-import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
-import React from 'react'; 
+import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
+import React from "react";
 
-import { MainScreen } from '../../screens/MainBottomTabs/MainScreen';
-import { SettingScreen } from '../../screens/MainBottomTabs/SettingScreen';
-import { SearchResultScreen } from '../../screens/MainBottomTabs/SearchResultScreen';
-import {TabIcon} from "../../components/Icons/TabIcon"
-const Tabs = createBottomTabNavigator(); 
+import { MainScreen } from "../../screens/MainBottomTabs/MainScreen";
+import { SettingScreen } from "../../screens/MainBottomTabs/SettingScreen";
+import { SearchResultScreen } from "../../screens/MainBottomTabs/SearchResultScreen";
+import { TabIcon } from "../../components/Icons/TabIcon";
+const Tabs = createBottomTabNavigator();
 
-export const MainBottomTabNavigation = ()=>
-{
-
-    return(
+export const MainBottomTabNavigation = ({ tabName }) => {
+  console.log("test", tabName);
+  return (
     <Tabs.Navigator
-    screenOptions={({route})=>({
-        headerShown:false,
-        tabBarIcon:({focused,color,size})=>{
-            const getIconName =()=>{
-                if(route.name==='Main'){
-                    return 'home'
-                }if(route.name==='SearchResult'){
-                    return 'compass'
-                }if(route.name=='Setting'){
-                    return 'ios-settings-outline'
-                }
+      screenOptions={({ route }) => ({
+        headerShown: false,
+        tabBarIcon: ({ focused, color, size }) => {
+          const getIconName = () => {
+            if (route.name === "Main") {
+              return "home";
             }
-            const iconName = getIconName() 
-            return(
-                <TabIcon iconName={iconName} iconColor={focused?color:'gray'}/>
-            )
-        }
-    }
-    )}
-
+            if (route.name === "SearchResult") {
+              return "compass";
+            }
+            if (route.name == "Setting") {
+              return "ios-settings-outline";
+            }
+          };
+          const iconName = getIconName();
+          return (
+            <TabIcon iconName={iconName} iconColor={focused ? color : "gray"} />
+          );
+        },
+      })}
     >
-        <Tabs.Screen name="Main" component={MainScreen}></Tabs.Screen>
-        <Tabs.Screen name="SearchResult" component={SearchResultScreen}></Tabs.Screen>
-        <Tabs.Screen name="Setting" component={SettingScreen}></Tabs.Screen>
-    </Tabs.Navigator>)
-    
-    
-}
+      <Tabs.Screen name="Main" component={MainScreen}></Tabs.Screen>
+      <Tabs.Screen
+        name="SearchResult"
+        component={SearchResultScreen}
+      ></Tabs.Screen>
+      <Tabs.Screen name="Setting" component={SettingScreen}></Tabs.Screen>
+    </Tabs.Navigator>
+  );
+};

--- a/SSoc-Client/src/navigations/MainNavigations/RootStackNavigation.js
+++ b/SSoc-Client/src/navigations/MainNavigations/RootStackNavigation.js
@@ -2,8 +2,10 @@ import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { MainBottomTabNavigation } from "./MainBottomTabNavigation";
 import { GroupDetailScreen } from "../../screens/GroupDetailScreen";
 import { SettingScreen } from "../../screens/MainBottomTabs/SettingScreen";
+import { GroupDetailStackNavigation } from "../GroupDetailNavigations/GroupDetailStackNavigation";
 const Stack = createNativeStackNavigator();
-export const RootStackNavigation = () => {
+export const RootStackNavigation = ({ route }) => {
+  console.log(route);
   return (
     <Stack.Navigator
       screenOptions={{
@@ -12,6 +14,11 @@ export const RootStackNavigation = () => {
     >
       <Stack.Screen name="MainBottomTab" component={MainBottomTabNavigation} />
       <Stack.Screen name="GroupDetailScreen" component={GroupDetailScreen} />
+      <Stack.Screen
+        name="GroupDetailTab"
+        component={GroupDetailStackNavigation}
+        options={route}
+      />
       <Stack.Screen name="SettingScreen" component={SettingScreen} />
     </Stack.Navigator>
   );

--- a/SSoc-Client/src/screens/GroupDetailBottomTabs/Board/BoardListScreen.js
+++ b/SSoc-Client/src/screens/GroupDetailBottomTabs/Board/BoardListScreen.js
@@ -1,0 +1,11 @@
+import { View } from "react-native";
+import { Typography } from "../../../components/Basic/Typography";
+import { StackHeader } from "../../../modules/StackHeader";
+
+export const BoardListScreen = () => {
+  return (
+    <View style={{ flex: 1 }}>
+      <StackHeader title={"게시판"}></StackHeader>
+    </View>
+  );
+};

--- a/SSoc-Client/src/screens/GroupDetailBottomTabs/Booking/BookingScreen.js
+++ b/SSoc-Client/src/screens/GroupDetailBottomTabs/Booking/BookingScreen.js
@@ -1,0 +1,10 @@
+import { View } from "react-native";
+import { Typography } from "../../../components/Basic/Typography";
+import { StackHeader } from "../../../modules/StackHeader";
+export const BookingScreen = () => {
+  return (
+    <View style={{ flex: 1 }}>
+      <StackHeader title={"게시판"}></StackHeader>
+    </View>
+  );
+};

--- a/SSoc-Client/src/screens/GroupDetailBottomTabs/Schedule/ScheduleScreen.js
+++ b/SSoc-Client/src/screens/GroupDetailBottomTabs/Schedule/ScheduleScreen.js
@@ -1,0 +1,10 @@
+import { View } from "react-native";
+import { Typography } from "../../../components/Basic/Typography";
+import { StackHeader } from "../../../modules/StackHeader";
+export const ScheduleScreen = () => {
+  return (
+    <View style={{ flex: 1 }}>
+      <StackHeader title={"일정"}></StackHeader>
+    </View>
+  );
+};

--- a/SSoc-Client/src/screens/GroupDetailBottomTabs/Settlement/SettlementScreen.js
+++ b/SSoc-Client/src/screens/GroupDetailBottomTabs/Settlement/SettlementScreen.js
@@ -1,0 +1,10 @@
+import { View } from "react-native";
+import { Typography } from "../../../components/Basic/Typography";
+import { StackHeader } from "../../../modules/StackHeader";
+export const SettlementScreen = () => {
+  return (
+    <View style={{ flex: 1 }}>
+      <StackHeader title="결산안" />
+    </View>
+  );
+};

--- a/SSoc-Client/src/screens/GroupDetailScreen.js
+++ b/SSoc-Client/src/screens/GroupDetailScreen.js
@@ -1,4 +1,10 @@
-import { View, Image, ScrollView, Animated, TouchableOpacity } from "react-native";
+import {
+  View,
+  Image,
+  ScrollView,
+  Animated,
+  TouchableOpacity,
+} from "react-native";
 import { LinearGradient } from "expo-linear-gradient";
 import { StackHeader } from "../modules/StackHeader";
 import defaultBg from "../../assets/basic_group_bgf.jpeg";
@@ -13,72 +19,61 @@ import { Icon } from "../components/Icons/Icons";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useCallback } from "react";
 import { useNavigation } from "@react-navigation/native";
-export const GroupDetailScreen = ({route}) => {
-  //to-do 
-    // 그룹아이디 같이 보냄 
-    // 해당 유저가 동아리 소속원인지, 동아리 소속원이 아닌지 
-    // 해당 유저가 동아리 매니저인지 동아리 매니저인지 받아옴 
-    //  버튼 동적 표현 구현   
+export const GroupDetailScreen = ({ route }) => {
+  //to-do
+  // 그룹아이디 같이 보냄
+  // 해당 유저가 동아리 소속원인지, 동아리 소속원이 아닌지
+  // 해당 유저가 동아리 매니저인지 동아리 매니저인지 받아옴
+  //  버튼 동적 표현 구현
 
   const { onScrollEndDrag, onScrollBeginDrag, onScroll, headerAnim } =
     useScrollEvent();
   const insets = useSafeAreaInsets();
   const navigation = useNavigation();
 
-  const {name, groupType, school, url, val, unit, subName}= route.params; 
+  const { name, groupType, school, url, val, unit, subName } = route.params;
 
-  const onPressGoBack = useCallback(()=>{
-    
-    navigation.goBack(); 
-  })
-
-
-
-  const onPressGoSettlement = useCallback(()=>{
-    console.log("결산안");
-    console.log(val, unit);
-    //to-do :  결산안 이동 
+  const onPressGoBack = useCallback(() => {
+    navigation.goBack();
   });
 
-  const onPressGoCommunity = useCallback(()=>{
-    console.log("커뮤니티 이동");
-  })
+  const onPressGoToTab = useCallback((tabName) => {
+    console.log(tabName);
+    navigation.navigate("GroupDetailTab", { tabName });
+  });
 
-  const onPressGoSchedule = useCallback(()=>{
-    console.log("일정 이동");
-  })
-
-  const onPressGoBooking = useCallback(()=>{
-    console.log("예약하기 ")
-  })
-
-    
-const ButtonData = [
-  {
-    title: "공금 사용현황",
-    onPress: onPressGoSettlement,
-  },
-  {
-    title: "커뮤니티 바로가기",
-    onPress: onPressGoCommunity,
-  },
-  {
-    title: "동아리 / 학생회 일정",
-    onPress: onPressGoSchedule,
-  },
-  {
-    title: "물품 예약",
-    onPress: onPressGoBooking,
-  },
-];
+  const ButtonData = [
+    {
+      title: "공금 사용현황",
+      tabName: "settlement",
+    },
+    {
+      title: "커뮤니티 바로가기",
+      tabName: "board",
+    },
+    {
+      title: "동아리 / 학생회 일정",
+      tabName: "schedlue",
+    },
+    {
+      title: "물품 예약",
+      tabName: "booking",
+    },
+  ];
 
   return (
     <View style={{ flex: 1 }}>
-      <TouchableOpacity onPress={onPressGoBack}  style={{ zIndex: 1 }}>
-            <View style={{ position: "absolute", paddingTop: insets.top, paddingHorizontal: 20 }}>
-              <Icon name="arrow-back" color="black" size={30} />
-            </View>
-          </TouchableOpacity>
+      <TouchableOpacity onPress={onPressGoBack} style={{ zIndex: 1 }}>
+        <View
+          style={{
+            position: "absolute",
+            paddingTop: insets.top,
+            paddingHorizontal: 20,
+          }}
+        >
+          <Icon name="arrow-back" color="black" size={30} />
+        </View>
+      </TouchableOpacity>
       <Animated.View
         style={{
           marginTop: headerAnim.interpolate({
@@ -101,11 +96,13 @@ const ButtonData = [
             backgroundColor: Color.BLACK,
           }}
         >
-         
           <View style={{ flex: 1 }}>
-            <Image source={require('../../assets/basic_group_bgf.jpeg')} style={{ width: "100%", height: 250 }} />
+            <Image
+              source={require("../../assets/basic_group_bgf.jpeg")}
+              style={{ width: "100%", height: 250 }}
+            />
           </View>
-          
+
           <View
             style={{
               backgroundColor: "rgba(0, 0, 0, 0.5)",
@@ -130,23 +127,27 @@ const ButtonData = [
         </View>
       </Animated.View>
       <SafeAreaView>
-      <Spacer space={250}/>
-      <ScrollView
-        scrollEventThrottle={1}
-        onScrollBeginDrag={onScrollBeginDrag}
-        onScroll={onScroll}
-        onScrollEndDrag={onScrollEndDrag}
-      >
-        <View style={{marginHorizontal:20}}>
+        <Spacer space={250} />
+        <ScrollView
+          scrollEventThrottle={1}
+          onScrollBeginDrag={onScrollBeginDrag}
+          onScroll={onScroll}
+          onScrollEndDrag={onScrollEndDrag}
+        >
+          <View style={{ marginHorizontal: 20 }}>
             <Typography fontSize={30}>{school}</Typography>
-            <Typography fontSize={22}>
-               {subName}
+            <Typography fontSize={22}>{subName}</Typography>
+            <Spacer space={5} />
+            <Typography fontSize={17} color={Color.GRAY}>
+              Update {val}
+              {unit} ago
             </Typography>
-            <Spacer space={5}/>
-            <Typography fontSize={17} color={Color.GRAY}>Update {val}{unit} ago</Typography>
-            <Spacer space={30}/>
+            <Spacer space={30} />
             {ButtonData.map((button, index) => (
-              <TouchableOpacity key={index} onPress={button.onPress}>
+              <TouchableOpacity
+                key={index}
+                onPress={() => onPressGoToTab(button.tabName)}
+              >
                 <View
                   style={{
                     backgroundColor: Color.BLUE,
@@ -163,34 +164,38 @@ const ButtonData = [
                 </View>
               </TouchableOpacity>
             ))}
-            <Spacer space={40}/>
+            <Spacer space={40} />
             <Typography fontSize={22}>About us</Typography>
-            <Spacer space={40}/>
+            <Spacer space={40} />
             <Typography fontSize={15}>
               {/* to-do :  group id 값으로 받아오기 */}
-            교내 중앙동아리 중 유일한 달리기 동아리이다. 
-            2011년 나이키 트레이닝 런에 참여하던 모임에서 출발해 함께 마라톤대회에 나가고 러닝 프로그램에 참여하는 교내 소모임의 성격이었다가, 2012년 하반기 가동아리 신청과 함께 본격적인 교내 동아리로 발전하였다.
-
-달리샤라는 이름은 동아리화에 대해 이야기하다 이것저것 막 던지다 정해진 것으로, 달리기+人(사람 인)+정문 샤 모양의 조합으로 달리人F로 정했고, 달리샤로 부르게 되었다.
-
-평일에는 교내 운동장 트랙 및 순환도로 달리기, 주말에는 나이키 트레이닝 런 또는 대회 참여 등 교외 달리기로 주2회 모임을 기본으로 하여, 현재(2018년 상반기 기준)도 수요일 저녁 교내 달리기, 토요일 오전 교외 달리기의 기조가 유지되고 있다(+모임 후기 작성자를 가위바위보로 정하는 것도 계속 유지되고 있다. 과거 활동했던 회원들에게는 아련한 추억일 듯하다.).
-
-한때는 맴버들끼리 '먹고 마시고 달리샤'라 부를 정도로 거의 매 모임마다 뒤풀이 및 번개 모임과 뒤풀이, 또는 그냥 먹고 마시는 모임들을 가졌었으나 정동아리가 되면서 회원수가 급증하고부터는 운동동아리 본연의 모습으로 돌아왔다.
-
-교내 구성원이면 상시 가입 가능하며, 모임 참여 및 회비 납부를 활동회원의 기준으로 하고 있다. 2020년 상반기에는 코로나19로 인해 다른 기준 적용되고 있다.
-
-자세한 내용은 인스타그램 달리샤 계정(http://www.instagram.com/snu_dalisha) 공지글 참조.
-
-2018년 상반기에 동아리방을 얻게 되어, 학생회관 616호를 동아리방으로 사용 중이다.(2020년 8월 기준)
-
-2021년에도 코로나로 인한 힘든시기를 겪고있으나 회장의 뛰어난 리더쉽으로 이끌어가는중이다.
+              교내 중앙동아리 중 유일한 달리기 동아리이다. 2011년 나이키
+              트레이닝 런에 참여하던 모임에서 출발해 함께 마라톤대회에 나가고
+              러닝 프로그램에 참여하는 교내 소모임의 성격이었다가, 2012년 하반기
+              가동아리 신청과 함께 본격적인 교내 동아리로 발전하였다. 달리샤라는
+              이름은 동아리화에 대해 이야기하다 이것저것 막 던지다 정해진
+              것으로, 달리기+人(사람 인)+정문 샤 모양의 조합으로 달리人F로
+              정했고, 달리샤로 부르게 되었다. 평일에는 교내 운동장 트랙 및
+              순환도로 달리기, 주말에는 나이키 트레이닝 런 또는 대회 참여 등
+              교외 달리기로 주2회 모임을 기본으로 하여, 현재(2018년 상반기
+              기준)도 수요일 저녁 교내 달리기, 토요일 오전 교외 달리기의 기조가
+              유지되고 있다(+모임 후기 작성자를 가위바위보로 정하는 것도 계속
+              유지되고 있다. 과거 활동했던 회원들에게는 아련한 추억일 듯하다.).
+              한때는 맴버들끼리 '먹고 마시고 달리샤'라 부를 정도로 거의 매
+              모임마다 뒤풀이 및 번개 모임과 뒤풀이, 또는 그냥 먹고 마시는
+              모임들을 가졌었으나 정동아리가 되면서 회원수가 급증하고부터는
+              운동동아리 본연의 모습으로 돌아왔다. 교내 구성원이면 상시 가입
+              가능하며, 모임 참여 및 회비 납부를 활동회원의 기준으로 하고 있다.
+              2020년 상반기에는 코로나19로 인해 다른 기준 적용되고 있다. 자세한
+              내용은 인스타그램 달리샤
+              계정(http://www.instagram.com/snu_dalisha) 공지글 참조. 2018년
+              상반기에 동아리방을 얻게 되어, 학생회관 616호를 동아리방으로 사용
+              중이다.(2020년 8월 기준) 2021년에도 코로나로 인한 힘든시기를
+              겪고있으나 회장의 뛰어난 리더쉽으로 이끌어가는중이다.
             </Typography>
-            
-        </View>
-      </ScrollView>
+          </View>
+        </ScrollView>
       </SafeAreaView>
-     
     </View>
   );
 };
-


### PR DESCRIPTION
**개요**

- #61 
- group detail bottom tab 구현 

**타입**

- [x]  feat : 새로운 기능 추가


**작업 사항**
- group detail bottom tab에 구현할 스크린을 정의하고 bottom tab을 구현하였습니다. 
- group detail bottom tab과 groupd detail screen을 navigation으로 연결시켰습니다. 
- 추후 group detail bottom tab 내에서 추가적으로 발생하는 screen은 group detail stack navigator에 등록만 하면 바로 사용가능합니다. 
- 필요없는 디버깅 log들을 제거하였습니다. 
- stack header 부분 가운데 정렬이 적용되지 않던 현상을 해결하였습니다. 