### PR TITLE
fix,chore: 그룹 정보 반환 시, 썸네일이 빠져있던 부분 수정 및 잘못된 메소드명 변경

### DIFF
--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/group/controller/GroupController.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/group/controller/GroupController.java
@@ -24,7 +24,7 @@ public class GroupController {
 	private final GroupService groupService;
 
 	@PostMapping("/edit")
-	public ResponseEntity<Message> createGroup(@RequestBody EditGroupInfoRequest request) {
+	public ResponseEntity<Message> editGroupInfo(@RequestBody EditGroupInfoRequest request) {
 		groupService.editGroupInfo(request);
 		return ResponseEntity.ok().body(Message.success());
 	}

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/group/controller/GroupMemberController.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/group/controller/GroupMemberController.java
@@ -19,7 +19,7 @@ public class GroupMemberController {
 	private final GroupMemberService groupMemberService;
 
 	@PostMapping("/role")
-	public ResponseEntity<Message<GetMemberRoleResponse>> createGroup(@RequestBody GetMemberRoleRequest request) {
+	public ResponseEntity<Message<GetMemberRoleResponse>> getMemberRole(@RequestBody GetMemberRoleRequest request) {
 		GetMemberRoleResponse memberRole = groupMemberService.getMemberRole(request);
 		return ResponseEntity.ok().body(Message.success(memberRole));
 	}

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/group/controller/GroupMemberController.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/group/controller/GroupMemberController.java
@@ -19,7 +19,7 @@ public class GroupMemberController {
 	private final GroupMemberService groupMemberService;
 
 	@PostMapping("/role")
-	public ResponseEntity<Message<GetMemberRoleResponse>> getMemberRole(@RequestBody GetMemberRoleRequest request) {
+	public ResponseEntity<Message<GetMemberRoleResponse>> createGroup(@RequestBody GetMemberRoleRequest request) {
 		GetMemberRoleResponse memberRole = groupMemberService.getMemberRole(request);
 		return ResponseEntity.ok().body(Message.success(memberRole));
 	}

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/group/dto/GroupSimpleInfo.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/group/dto/GroupSimpleInfo.java
@@ -18,6 +18,7 @@ public class GroupSimpleInfo {
 	private String name;
 	private String aboutUs;
 	private String school;
+	private String thumbnail;
 
 
 }

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/group/repository/impl/QueryDslGroupRepositoryImpl.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/group/repository/impl/QueryDslGroupRepositoryImpl.java
@@ -30,7 +30,8 @@ public class QueryDslGroupRepositoryImpl implements QueryDslGroupRepository {
 					group.id.as("groupId"),
 				group.name.as("name"),
 				group.aboutUs.as("aboutUs"),
-				school.name.as("school")
+				school.name.as("school"),
+				group.thumbnail.as("thumbnail")
 				))
 			.from(group)
 			.innerJoin(group.school, school)
@@ -47,7 +48,8 @@ public class QueryDslGroupRepositoryImpl implements QueryDslGroupRepository {
 				group.id.as("groupId"),
 				group.name.as("name"),
 				group.aboutUs.as("aboutUs"),
-				school.name.as("school")
+				school.name.as("school"),
+				group.thumbnail.as("thumbnail")
 			))
 			.from(groupMember)
 			.innerJoin(groupMember.group, group)


### PR DESCRIPTION
**개요**

- #28 
- 그룹 정보 반환 시, 썸네일이 빠져있던 부분 수정 및 잘못된 메소드명 변경

**타입**

- [x]  fix : 버그 수정이나 로직 변경 등의 수정
- [x]  chore : 그 외 자잘한 수정에 대한 커밋(오탈자 등)


**작업 사항**
- 그룹 컨트롤러에서 메소드명들이 잘못되어있는 것을 발견하고 수정
- 그룹 정보 반환 시, 썸네일 값도 같이 반환하도록 변경

