### PR TITLE
feat: 그룹 계좌 거래내역 페이징 조회 API 구현

### DIFF
--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/controller/TransactionController.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/controller/TransactionController.java
@@ -1,8 +1,11 @@
 package gwangju.ssafy.backend.domain.transaction.controller;
 
 import gwangju.ssafy.backend.domain.transaction.dto.EditTransactionNoteRequest;
+import gwangju.ssafy.backend.domain.transaction.dto.GetTransactionsRequest;
+import gwangju.ssafy.backend.domain.transaction.dto.TransactionInfo;
 import gwangju.ssafy.backend.domain.transaction.service.TransactionService;
 import gwangju.ssafy.backend.global.common.dto.Message;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -11,7 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
-@RequestMapping("/group/transaction")
+@RequestMapping("/group/account/transaction")
 @RestController
 public class TransactionController {
 
@@ -21,6 +24,12 @@ public class TransactionController {
 	public ResponseEntity<Message> editNote(@RequestBody EditTransactionNoteRequest request) {
 		transactionService.editNote(request);
 		return ResponseEntity.ok().body(Message.success());
+	}
+
+	@PostMapping
+	public ResponseEntity<Message<List<TransactionInfo>>> getTransactions(
+		@RequestBody GetTransactionsRequest request) {
+		return ResponseEntity.ok().body(Message.success(transactionService.getTransactions(request)));
 	}
 
 }

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/dto/GetTransactionsRequest.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/dto/GetTransactionsRequest.java
@@ -1,0 +1,29 @@
+package gwangju.ssafy.backend.domain.transaction.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import java.awt.print.Pageable;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+@Setter
+public class GetTransactionsRequest {
+
+	private Long userId;
+	private Long groupId;
+	private String accountNumber;
+	@NotNull
+	@Min(1)
+	@Max(100)
+	private Long limit;
+	private long pageNumber;
+
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/dto/TransactionInfo.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/dto/TransactionInfo.java
@@ -1,0 +1,29 @@
+package gwangju.ssafy.backend.domain.transaction.dto;
+
+import jakarta.transaction.Transaction;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+@Setter
+public class TransactionInfo {
+	private Long transactionId;
+	private Long groupAccountId;
+	private LocalDateTime date;
+	private String briefs;
+	private Long withdrawal;
+	private Long deposit;
+	private String detail;
+	private Long balance;
+	private String category;
+	private String branch;
+	private String note;
+
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/repository/QueryDslTransactionRepository.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/repository/QueryDslTransactionRepository.java
@@ -1,0 +1,11 @@
+package gwangju.ssafy.backend.domain.transaction.repository;
+
+import gwangju.ssafy.backend.domain.transaction.dto.TransactionInfo;
+import java.util.List;
+
+public interface QueryDslTransactionRepository {
+
+	// 그룹 필터링 및 페이징 조회
+	List<TransactionInfo> findAllByGroupAccountId(Long accountId, Long limit, Long pageNum);
+
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/repository/TransactionRepository.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/repository/TransactionRepository.java
@@ -3,7 +3,7 @@ package gwangju.ssafy.backend.domain.transaction.repository;
 import gwangju.ssafy.backend.domain.transaction.entity.Transaction;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface TransactionRepository extends JpaRepository<Transaction, Long>,TransactionBatchRepository {
+public interface TransactionRepository extends JpaRepository<Transaction, Long>,TransactionBatchRepository, QueryDslTransactionRepository {
 
 	int countByGroupAccount_Id(Long groupAccountId);
 

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/repository/impl/QueryDslTransactionRepositoryImpl.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/repository/impl/QueryDslTransactionRepositoryImpl.java
@@ -1,0 +1,45 @@
+package gwangju.ssafy.backend.domain.transaction.repository.impl;
+
+import static gwangju.ssafy.backend.domain.transaction.entity.QGroupAccount.groupAccount;
+import static gwangju.ssafy.backend.domain.transaction.entity.QTransaction.transaction;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import gwangju.ssafy.backend.domain.transaction.dto.GetTransactionsRequest;
+import gwangju.ssafy.backend.domain.transaction.dto.TransactionInfo;
+import gwangju.ssafy.backend.domain.transaction.repository.QueryDslTransactionRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class QueryDslTransactionRepositoryImpl implements QueryDslTransactionRepository {
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	@Override
+	public List<TransactionInfo> findAllByGroupAccountId(Long accountId, Long limit, Long pageNum) {
+		return jpaQueryFactory.select(Projections.fields(TransactionInfo.class,
+				transaction.id.as("transactionId"),
+				groupAccount.id.as("groupAccountId"),
+				transaction.date.as("date"),
+				transaction.briefs.as("briefs"),
+				transaction.withdrawal.as("withdrawal"),
+				transaction.deposit.as("deposit"),
+				transaction.detail.as("detail"),
+				transaction.balance.as("balance"),
+				transaction.category.as("category"),
+				transaction.branch.as("branch"),
+				transaction.note.as("note")
+				))
+			.from(transaction)
+			.innerJoin(transaction.groupAccount, groupAccount)
+			.where(groupAccount.id.eq(accountId))
+			.orderBy(transaction.date.desc())
+			.limit(limit)
+			.offset(pageNum * limit)
+			.fetch();
+	}
+
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/service/TransactionService.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/service/TransactionService.java
@@ -1,8 +1,13 @@
 package gwangju.ssafy.backend.domain.transaction.service;
 
 import gwangju.ssafy.backend.domain.transaction.dto.EditTransactionNoteRequest;
+import gwangju.ssafy.backend.domain.transaction.dto.GetTransactionsRequest;
+import gwangju.ssafy.backend.domain.transaction.dto.TransactionInfo;
+import java.util.List;
 
 public interface TransactionService {
 
 	void editNote(EditTransactionNoteRequest request);
+
+	List<TransactionInfo> getTransactions(GetTransactionsRequest request);
 }

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/service/impl/TransactionServiceImpl.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/service/impl/TransactionServiceImpl.java
@@ -4,11 +4,14 @@ import gwangju.ssafy.backend.domain.group.entity.GroupMember;
 import gwangju.ssafy.backend.domain.group.entity.enums.GroupMemberRole;
 import gwangju.ssafy.backend.domain.group.repository.GroupMemberRepository;
 import gwangju.ssafy.backend.domain.transaction.dto.EditTransactionNoteRequest;
+import gwangju.ssafy.backend.domain.transaction.dto.GetTransactionsRequest;
+import gwangju.ssafy.backend.domain.transaction.dto.TransactionInfo;
 import gwangju.ssafy.backend.domain.transaction.entity.GroupAccount;
 import gwangju.ssafy.backend.domain.transaction.entity.Transaction;
 import gwangju.ssafy.backend.domain.transaction.repository.GroupAccountRepository;
 import gwangju.ssafy.backend.domain.transaction.repository.TransactionRepository;
 import gwangju.ssafy.backend.domain.transaction.service.TransactionService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,5 +45,23 @@ public class TransactionServiceImpl implements TransactionService {
 		}
 
 		transaction.changeNote(request.getNote());
+	}
+
+	@Override
+	public List<TransactionInfo> getTransactions(GetTransactionsRequest request) {
+
+		GroupAccount account = groupAccountRepository.findByGroupIdAndNumber(request.getGroupId(),
+				request.getAccountNumber())
+			.orElseThrow(() -> new RuntimeException("없는 계좌"));
+
+		if (!account.isActive()) {
+			throw new RuntimeException("비활성화된 계좌");
+		}
+
+		groupMemberRepository.findByGroupIdAndUserId(request.getGroupId(), request.getUserId())
+			.orElseThrow(() -> new RuntimeException("그룹원이 아님"));
+
+		return transactionRepository.findAllByGroupAccountId(account.getId(), request.getLimit(),
+			request.getPageNumber());
 	}
 }

--- a/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/jobs/DailyTransactionReader.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/jobs/DailyTransactionReader.java
@@ -1,7 +1,7 @@
 package gwangju.ssafy.backend.global.infra.batch.jobs;
 
 import gwangju.ssafy.backend.global.infra.feign.shinhan.service.ShinhanBankService;
-import gwangju.ssafy.backend.global.infra.feign.shinhan.dto.TransactionInfo;
+import gwangju.ssafy.backend.global.infra.feign.shinhan.dto.ShinhanTransactionInfo;
 import gwangju.ssafy.backend.domain.transaction.entity.GroupAccount;
 import gwangju.ssafy.backend.domain.transaction.entity.Transaction;
 import gwangju.ssafy.backend.domain.transaction.repository.GroupAccountRepository;
@@ -37,10 +37,10 @@ public class DailyTransactionReader implements ItemReader<List<Transaction>> {
 		for (GroupAccount groupAccount : all) {
 			String accountNumber = groupAccount.getNumber();
 			log.info("===== 결산 중인 계좌 : {} ======", accountNumber);
-			TransactionInfo info = shinhanBankService.getAccountTransaction(
+			ShinhanTransactionInfo info = shinhanBankService.getAccountTransaction(
 				accountNumber);
 
-			List<TransactionInfo.Transaction> transactions = info.getTransactions();
+			List<ShinhanTransactionInfo.Transaction> transactions = info.getTransactions();
 
 			int cnt = transactionRepository.countByGroupAccount_Id(groupAccount.getId());
 			log.info("===== 기존 거래내역 개수 : {} =====", cnt);
@@ -49,7 +49,7 @@ public class DailyTransactionReader implements ItemReader<List<Transaction>> {
 			log.info("===== 새로 저장할 내역 개수 : {} =====", diff);
 
 			for (int i = 0; i < diff; i++) {
-				TransactionInfo.Transaction transaction = transactions.get(i);
+				ShinhanTransactionInfo.Transaction transaction = transactions.get(i);
 
 				Transaction result = Transaction.builder()
 					.balance(transaction.getBalance())

--- a/Backend/src/main/java/gwangju/ssafy/backend/global/infra/feign/shinhan/dto/ShinhanTransactionApi.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/global/infra/feign/shinhan/dto/ShinhanTransactionApi.java
@@ -31,8 +31,8 @@ public class ShinhanTransactionApi {
 		private Long 거래내역반복횟수;
 		private List<Transaction> 거래내역;
 
-		public TransactionInfo toDto() {
-			return TransactionInfo.builder()
+		public ShinhanTransactionInfo toDto() {
+			return ShinhanTransactionInfo.builder()
 				.accountNumber(this.계좌번호)
 				.productName(this.상품명)
 				.balance(this.계좌잔액)
@@ -42,8 +42,8 @@ public class ShinhanTransactionApi {
 				.build();
 		}
 
-		private List<TransactionInfo.Transaction> toList() {
-			ArrayList<TransactionInfo.Transaction> list = new ArrayList<>();
+		private List<ShinhanTransactionInfo.Transaction> toList() {
+			ArrayList<ShinhanTransactionInfo.Transaction> list = new ArrayList<>();
 			for (Transaction transaction : 거래내역) {
 				list.add(transaction.toDto());
 			}
@@ -68,8 +68,8 @@ public class ShinhanTransactionApi {
 		private String 입지구분;
 		private String 거래점명;
 
-		public TransactionInfo.Transaction toDto() {
-			return TransactionInfo.Transaction.builder()
+		public ShinhanTransactionInfo.Transaction toDto() {
+			return ShinhanTransactionInfo.Transaction.builder()
 				.date(LocalDateTime.parse(this.거래일자 + this.거래시간,formatter))
 				.briefs(this.적요)
 				.withdrawal(this.출금금액)

--- a/Backend/src/main/java/gwangju/ssafy/backend/global/infra/feign/shinhan/dto/ShinhanTransactionInfo.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/global/infra/feign/shinhan/dto/ShinhanTransactionInfo.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 @Getter
-public class TransactionInfo {
+public class ShinhanTransactionInfo {
 	private String accountNumber;
 	private String productName;
 	private String balance;

--- a/Backend/src/main/java/gwangju/ssafy/backend/global/infra/feign/shinhan/service/ShinhanBankService.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/global/infra/feign/shinhan/service/ShinhanBankService.java
@@ -1,7 +1,7 @@
 package gwangju.ssafy.backend.global.infra.feign.shinhan.service;
 
 
-import gwangju.ssafy.backend.global.infra.feign.shinhan.dto.TransactionInfo;
+import gwangju.ssafy.backend.global.infra.feign.shinhan.dto.ShinhanTransactionInfo;
 import gwangju.ssafy.backend.global.infra.feign.shinhan.dto.TransferRequest;
 import gwangju.ssafy.backend.global.infra.feign.shinhan.dto.TransferResult;
 import gwangju.ssafy.backend.global.infra.feign.shinhan.dto.DepositHolderName;
@@ -12,7 +12,7 @@ public interface ShinhanBankService {
 
 	BalanceDetail getBalanceDetail(String accountNumber);
 
-	TransactionInfo getAccountTransaction(String accountNumber);
+	ShinhanTransactionInfo getAccountTransaction(String accountNumber);
 
 	DepositHolderName searchDepositHolderName(String depositBankCode, String depositAccountNumber);
 

--- a/Backend/src/main/java/gwangju/ssafy/backend/global/infra/feign/shinhan/service/impl/ShinhanBankServiceImpl.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/global/infra/feign/shinhan/service/impl/ShinhanBankServiceImpl.java
@@ -9,13 +9,12 @@ import gwangju.ssafy.backend.global.infra.feign.shinhan.dto.ShinhanSearchNameApi
 import gwangju.ssafy.backend.global.infra.feign.shinhan.dto.ShinhanTransactionApi;
 import gwangju.ssafy.backend.global.infra.feign.shinhan.dto.ShinhanTransferApi;
 import gwangju.ssafy.backend.global.infra.feign.shinhan.dto.ShinhanTransferAuthApi;
-import gwangju.ssafy.backend.global.infra.feign.shinhan.dto.TransactionInfo;
+import gwangju.ssafy.backend.global.infra.feign.shinhan.dto.ShinhanTransactionInfo;
 import gwangju.ssafy.backend.global.infra.feign.shinhan.dto.TransferRequest;
 import gwangju.ssafy.backend.global.infra.feign.shinhan.dto.TransferResult;
 import gwangju.ssafy.backend.global.infra.feign.shinhan.dto.DepositHolderName;
 import gwangju.ssafy.backend.global.infra.feign.shinhan.dto.BalanceDetail;
 import gwangju.ssafy.backend.global.infra.feign.shinhan.service.ShinhanBankService;
-import gwangju.ssafy.backend.global.infra.feign.shinhan.service.impl.ShinhanApiKey;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -43,7 +42,7 @@ class ShinhanBankServiceImpl implements ShinhanBankService {
 	}
 
 	@Override
-	public TransactionInfo getAccountTransaction(String accountNumber) {
+	public ShinhanTransactionInfo getAccountTransaction(String accountNumber) {
 
 		ShinhanApiDto<ShinhanApiKey, ShinhanTransactionApi.Request> request = ShinhanApiDto.<ShinhanApiKey, ShinhanTransactionApi.Request>builder()
 			.dataHeader(apiKey)


### PR DESCRIPTION
**개요**

- #16 
- 그룹 계좌 거래 내역 페이징 조회 API 구현

**타입**

- [x]  feat : 새로운 기능 추가


**작업 사항**
- querydsl을 이용하여 그룹 계좌 거래 내역 페이징 조회 API 구현했습니다.