### PR TITLE
feat: 매일 그룹 계좌 거래내역 통계 배치 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,4 @@ out/
 .vscode/
 
 
-
+Backend/src/main/generated/

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/entity/DailyTransactionStatistics.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/entity/DailyTransactionStatistics.java
@@ -1,0 +1,47 @@
+package gwangju.ssafy.backend.domain.transaction.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class DailyTransactionStatistics {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@JoinColumn
+	private Long groupAccountId;
+
+	@Column
+	private Long withdrawal;
+
+	@Column
+	private Long deposit;
+
+	@Column
+	private LocalDate date;
+
+	@Column
+	private String dayOfWeek;
+
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/dto/TransactionStatisticsBatchDto.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/dto/TransactionStatisticsBatchDto.java
@@ -1,0 +1,33 @@
+package gwangju.ssafy.backend.global.infra.batch.dto;
+
+import gwangju.ssafy.backend.domain.transaction.entity.DailyTransactionStatistics;
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class TransactionStatisticsBatchDto {
+	// groupAccountId
+	private Long id;
+	private Long totalWithdrawal;
+	private Long totalDeposit;
+	private LocalDate startDate;
+	private LocalDate endDate;
+
+	public DailyTransactionStatistics toEntity() {
+		return DailyTransactionStatistics.builder()
+			.groupAccountId(this.id)
+			.withdrawal(this.totalWithdrawal)
+			.deposit(this.totalDeposit)
+			.date(this.startDate)
+			.dayOfWeek(this.startDate.getDayOfWeek().name())
+			.build();
+	}
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/jobs/DailyTransactionStatisticsJobConfig.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/jobs/DailyTransactionStatisticsJobConfig.java
@@ -1,0 +1,105 @@
+package gwangju.ssafy.backend.global.infra.batch.jobs;
+
+import static gwangju.ssafy.backend.domain.transaction.entity.QGroupAccount.groupAccount;
+import static gwangju.ssafy.backend.domain.transaction.entity.QTransaction.transaction;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
+import gwangju.ssafy.backend.domain.transaction.entity.DailyTransactionStatistics;
+import gwangju.ssafy.backend.domain.transaction.entity.QGroupAccount;
+import gwangju.ssafy.backend.global.infra.batch.dto.TransactionStatisticsBatchDto;
+import gwangju.ssafy.backend.global.infra.batch.library.querydsl.reader.QuerydslNoOffsetIdPagingItemReader;
+import gwangju.ssafy.backend.global.infra.batch.library.querydsl.reader.expression.Expression;
+import gwangju.ssafy.backend.global.infra.batch.library.querydsl.reader.options.QuerydslNoOffsetNumberOptions;
+import gwangju.ssafy.backend.global.infra.batch.params.DailyTransactionStatisticsParam;
+import jakarta.persistence.EntityManagerFactory;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import javax.sql.DataSource;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobScope;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.database.JdbcBatchItemWriter;
+import org.springframework.batch.item.database.builder.JdbcBatchItemWriterBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class DailyTransactionStatisticsJobConfig {
+
+	private static final int CHUNK_SIZE = 100;
+	private final EntityManagerFactory emf;
+	private final DailyTransactionStatisticsParam jobParam;
+	private final DataSource dataSource;
+
+
+	@Bean
+	public Job dailyTransactionStatisticsJob(JobRepository jobRepository,
+		PlatformTransactionManager platformTransactionManager) {
+		return new JobBuilder("daily_transaction_statistics", jobRepository)
+			.start(dailyTransactionStatisticsStep(jobRepository, platformTransactionManager))
+			.build();
+	}
+
+	@Bean
+	@JobScope
+	public Step dailyTransactionStatisticsStep(JobRepository jobRepository,
+		PlatformTransactionManager transactionManager) {
+		return new StepBuilder("daily_transaction_statistics", jobRepository)
+			.<TransactionStatisticsBatchDto, DailyTransactionStatistics>chunk(CHUNK_SIZE,
+				transactionManager)
+			.reader(dailyTransactionStatisticsReader())
+			.processor(dailyTransactionStatisticsProcessor())
+			.writer(dailyTransactionStatisticsWriter())
+			.build();
+	}
+
+	@Bean
+	@JobScope
+	public QuerydslNoOffsetIdPagingItemReader<TransactionStatisticsBatchDto, Long> dailyTransactionStatisticsReader() {
+		QuerydslNoOffsetNumberOptions<TransactionStatisticsBatchDto, Long> options =
+			new QuerydslNoOffsetNumberOptions<>(transaction.groupAccount.id, Expression.ASC);
+
+		return new QuerydslNoOffsetIdPagingItemReader<>(emf, CHUNK_SIZE, options,
+			queryFactory -> queryFactory
+				.select(Projections.fields(TransactionStatisticsBatchDto.class,
+					transaction.groupAccount.id.as("id"),
+					transaction.withdrawal.sum().as("totalWithdrawal"),
+					transaction.deposit.sum().as("totalDeposit"),
+					Expressions.asDate(jobParam.getStartDate()).as("startDate"),
+					Expressions.asDate(jobParam.getEndDate()).as("endDate")))
+				.from(transaction)
+				.where(transaction.date.goe(LocalDateTime.of(jobParam.getStartDate(),
+				LocalTime.MIN)),
+			transaction.date.lt(LocalDateTime.of(jobParam.getEndDate(), LocalTime.MIN)))
+			.groupBy(transaction.groupAccount.id)
+		);
+	}
+
+	@Bean
+	@StepScope
+	public ItemProcessor<TransactionStatisticsBatchDto, DailyTransactionStatistics> dailyTransactionStatisticsProcessor() {
+		return TransactionStatisticsBatchDto::toEntity;
+	}
+
+	@Bean
+	@StepScope
+	public JdbcBatchItemWriter<DailyTransactionStatistics> dailyTransactionStatisticsWriter() {
+		return new JdbcBatchItemWriterBuilder<DailyTransactionStatistics>()
+			.dataSource(dataSource)
+			.sql("insert into daily_transaction_statistics(group_account_id, withdrawal, deposit, date, day_of_week) values(:groupAccountId, :withdrawal, :deposit, :date, :dayOfWeek)")
+			.beanMapped()
+			.build();
+	}
+
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/library/querydsl/reader/QuerydslNoOffsetIdPagingItemReader.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/library/querydsl/reader/QuerydslNoOffsetIdPagingItemReader.java
@@ -1,0 +1,70 @@
+package gwangju.ssafy.backend.global.infra.batch.library.querydsl.reader;
+
+import com.querydsl.jpa.JPQLQuery;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import gwangju.ssafy.backend.global.infra.batch.library.querydsl.reader.options.QuerydslNoOffsetNumberOptions;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityTransaction;
+import java.util.function.Function;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.CollectionUtils;
+
+public class QuerydslNoOffsetIdPagingItemReader<T, N extends Number & Comparable<?>> extends
+	QuerydslPagingItemReader<T> {
+
+    private QuerydslNoOffsetNumberOptions<T, N> options;
+
+    private QuerydslNoOffsetIdPagingItemReader() {
+        super();
+        setName(ClassUtils.getShortName(QuerydslNoOffsetIdPagingItemReader.class));
+    }
+
+    public QuerydslNoOffsetIdPagingItemReader(EntityManagerFactory entityManagerFactory,
+                                              int pageSize,
+                                              QuerydslNoOffsetNumberOptions<T, N> options,
+                                              Function<JPAQueryFactory, JPAQuery<T>> queryFunction) {
+        super(entityManagerFactory, pageSize, queryFunction);
+        setName(ClassUtils.getShortName(QuerydslNoOffsetIdPagingItemReader.class));
+        this.options = options;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected void doReadPage() {
+
+        EntityTransaction tx = getTxOrNull();
+
+        JPQLQuery<T> query = createQuery().limit(getPageSize());
+
+        initResults();
+
+        fetchQuery(query, tx);
+
+        resetCurrentIdIfNotLastPage();
+    }
+
+    @Override
+    protected JPAQuery<T> createQuery() {
+        JPAQueryFactory queryFactory = new JPAQueryFactory(entityManager);
+        JPAQuery<T> query = queryFunction.apply(queryFactory);
+        options.initKeys(query, getPage()); // 제일 첫번째 페이징시 시작해야할 ID 찾기
+
+        return options.createQuery(query, getPage());
+    }
+
+    private void resetCurrentIdIfNotLastPage() {
+        if (isNotEmptyResults()) {
+            options.resetCurrentId(getLastItem());
+        }
+    }
+
+    // 조회결과가 Empty이면 results에 null이 담긴다
+    private boolean isNotEmptyResults() {
+        return !CollectionUtils.isEmpty(results) && results.get(0) != null;
+    }
+
+    private T getLastItem() {
+        return results.get(results.size() - 1);
+    }
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/library/querydsl/reader/QuerydslNoOffsetPagingItemReader.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/library/querydsl/reader/QuerydslNoOffsetPagingItemReader.java
@@ -1,0 +1,69 @@
+package gwangju.ssafy.backend.global.infra.batch.library.querydsl.reader;
+
+import com.querydsl.jpa.JPQLQuery;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import gwangju.ssafy.backend.global.infra.batch.library.querydsl.reader.options.QuerydslNoOffsetOptions;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityTransaction;
+import java.util.function.Function;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.CollectionUtils;
+
+public class QuerydslNoOffsetPagingItemReader<T> extends QuerydslPagingItemReader<T> {
+
+    private QuerydslNoOffsetOptions<T> options;
+
+    private QuerydslNoOffsetPagingItemReader() {
+        super();
+        setName(ClassUtils.getShortName(QuerydslNoOffsetPagingItemReader.class));
+    }
+
+    public QuerydslNoOffsetPagingItemReader(EntityManagerFactory entityManagerFactory,
+                                            int pageSize,
+                                            QuerydslNoOffsetOptions<T> options,
+                                            Function<JPAQueryFactory, JPAQuery<T>> queryFunction) {
+        super(entityManagerFactory, pageSize, queryFunction);
+        setName(ClassUtils.getShortName(QuerydslNoOffsetPagingItemReader.class));
+        this.options = options;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected void doReadPage() {
+
+        EntityTransaction tx = getTxOrNull();
+
+        JPQLQuery<T> query = createQuery().limit(getPageSize());
+
+        initResults();
+
+        fetchQuery(query, tx);
+
+        resetCurrentIdIfNotLastPage();
+    }
+
+    @Override
+    protected JPAQuery<T> createQuery() {
+        JPAQueryFactory queryFactory = new JPAQueryFactory(entityManager);
+        JPAQuery<T> query = queryFunction.apply(queryFactory);
+        options.initKeys(query, getPage()); // 제일 첫번째 페이징시 시작해야할 ID 찾기
+
+        return options.createQuery(query, getPage());
+    }
+
+    private void resetCurrentIdIfNotLastPage() {
+        if (isNotEmptyResults()) {
+            options.resetCurrentId(getLastItem());
+        }
+    }
+
+    // 조회결과가 Empty이면 results에 null이 담긴다
+    private boolean isNotEmptyResults() {
+        return !CollectionUtils.isEmpty(results) && results.get(0) != null;
+    }
+
+    private T getLastItem() {
+        return results.get(results.size() - 1);
+    }
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/library/querydsl/reader/QuerydslPagingItemReader.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/library/querydsl/reader/QuerydslPagingItemReader.java
@@ -1,0 +1,137 @@
+package gwangju.ssafy.backend.global.infra.batch.library.querydsl.reader;
+
+import com.querydsl.jpa.JPQLQuery;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityTransaction;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Function;
+import org.springframework.batch.item.database.AbstractPagingItemReader;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.CollectionUtils;
+
+public class QuerydslPagingItemReader<T> extends AbstractPagingItemReader<T> {
+
+    protected final Map<String, Object> jpaPropertyMap = new HashMap<>();
+    protected EntityManagerFactory entityManagerFactory;
+    protected EntityManager entityManager;
+    protected Function<JPAQueryFactory, JPAQuery<T>> queryFunction;
+    protected boolean transacted = true; // default value
+
+    protected QuerydslPagingItemReader() {
+        setName(ClassUtils.getShortName(QuerydslPagingItemReader.class));
+    }
+
+    public QuerydslPagingItemReader(EntityManagerFactory entityManagerFactory,
+                                    int pageSize,
+                                    Function<JPAQueryFactory, JPAQuery<T>> queryFunction) {
+        this(entityManagerFactory, pageSize, true, queryFunction);
+    }
+
+    public QuerydslPagingItemReader(EntityManagerFactory entityManagerFactory,
+                                    int pageSize,
+                                    boolean transacted,
+                                    Function<JPAQueryFactory, JPAQuery<T>> queryFunction) {
+        this();
+        this.entityManagerFactory = entityManagerFactory;
+        this.queryFunction = queryFunction;
+        setPageSize(pageSize);
+        setTransacted(transacted);
+    }
+
+    /**
+     * Reader의 트랜잭션격리 옵션 <br/>
+     * - false: 격리 시키지 않고, Chunk 트랜잭션에 의존한다 <br/>
+     * (hibernate.default_batch_fetch_size 옵션 사용가능) <br/>
+     * - true: 격리 시킨다 <br/>
+     * (Reader 조회 결과를 삭제하고 다시 조회했을때 삭제된게 반영되고 조회되길 원할때 사용한다.)
+     */
+    public void setTransacted(boolean transacted) {
+        this.transacted = transacted;
+    }
+
+    @Override
+    protected void doOpen() throws Exception {
+        super.doOpen();
+
+        entityManager = entityManagerFactory.createEntityManager(jpaPropertyMap);
+        if (entityManager == null) {
+            throw new DataAccessResourceFailureException("Unable to obtain an EntityManager");
+        }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected void doReadPage() {
+        EntityTransaction tx = getTxOrNull();
+
+        JPQLQuery<T> query = createQuery()
+                .offset(getPage() * getPageSize())
+                .limit(getPageSize());
+
+        initResults();
+
+        fetchQuery(query, tx);
+    }
+
+    protected EntityTransaction getTxOrNull() {
+        if (transacted) {
+            EntityTransaction tx = entityManager.getTransaction();
+            tx.begin();
+
+            entityManager.flush();
+            entityManager.clear();
+            return tx;
+        }
+
+        return null;
+    }
+
+    protected JPAQuery<T> createQuery() {
+        JPAQueryFactory queryFactory = new JPAQueryFactory(entityManager);
+        return queryFunction.apply(queryFactory);
+    }
+
+    protected void initResults() {
+        if (CollectionUtils.isEmpty(results)) {
+            results = new CopyOnWriteArrayList<>();
+        } else {
+            results.clear();
+        }
+    }
+
+    /**
+     * where 의 조건은 id max/min 을 이용한 제한된 범위를 가지게 한다
+     * @param query
+     * @param tx
+     */
+    protected void fetchQuery(JPQLQuery<T> query, EntityTransaction tx) {
+        if (transacted) {
+            results.addAll(query.fetch());
+            if(tx != null) {
+                tx.commit();
+            }
+        } else {
+            List<T> queryResult = query.fetch();
+            for (T entity : queryResult) {
+                entityManager.detach(entity);
+                results.add(entity);
+            }
+        }
+    }
+
+    protected void doJumpToPage(int itemIndex) {
+    }
+
+    @Override
+    protected void doClose() throws Exception {
+        entityManager.close();
+        super.doClose();
+    }
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/library/querydsl/reader/QuerydslZeroPagingItemReader.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/library/querydsl/reader/QuerydslZeroPagingItemReader.java
@@ -1,0 +1,48 @@
+package gwangju.ssafy.backend.global.infra.batch.library.querydsl.reader;
+
+import com.querydsl.jpa.JPQLQuery;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityTransaction;
+import java.util.function.Function;
+import org.springframework.util.ClassUtils;
+
+/**
+ * 배치의 형태가 삭제/수정으로 인해 조회 결과가 계속 동적으로 변경될때 사용할 Reader
+ * 참고: https://jojoldu.tistory.com/337
+ *
+ */
+public class QuerydslZeroPagingItemReader<T> extends QuerydslPagingItemReader<T> {
+
+    public QuerydslZeroPagingItemReader() {
+        super();
+        setName(ClassUtils.getShortName(QuerydslZeroPagingItemReader.class));
+    }
+
+    public QuerydslZeroPagingItemReader(EntityManagerFactory entityManagerFactory,
+                                        int pageSize,
+                                        Function<JPAQueryFactory, JPAQuery<T>> queryFunction) {
+        this();
+        setTransacted(true);
+        super.entityManagerFactory = entityManagerFactory;
+        super.queryFunction = queryFunction;
+        setPageSize(pageSize);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected void doReadPage() {
+
+        EntityTransaction tx = getTxOrNull();
+
+        JPQLQuery<T> query = createQuery()
+                .offset(0)
+                .limit(getPageSize());
+
+        initResults();
+
+        fetchQuery(query, tx);
+    }
+
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/library/querydsl/reader/expression/Expression.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/library/querydsl/reader/expression/Expression.java
@@ -1,0 +1,44 @@
+package gwangju.ssafy.backend.global.infra.batch.library.querydsl.reader.expression;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.NumberPath;
+import com.querydsl.core.types.dsl.StringPath;
+
+/**
+ * Created by jojoldu@gmail.com on 23/01/2020
+ * Blog : http://jojoldu.tistory.com
+ * Github : http://github.com/jojoldu
+ */
+public enum Expression {
+    ASC(WhereExpression.GT, OrderExpression.ASC),
+    DESC(WhereExpression.LT, OrderExpression.DESC);
+
+    private final WhereExpression where;
+    private final OrderExpression order;
+
+    Expression(WhereExpression where, OrderExpression order) {
+        this.where = where;
+        this.order = order;
+    }
+
+    public boolean isAsc() {
+        return this == ASC;
+    }
+
+    public BooleanExpression where (StringPath id, int page, String currentId) {
+        return where.expression(id, page, currentId);
+    }
+
+    public <N extends Number & Comparable<?>> BooleanExpression where (NumberPath<N> id, int page, N currentId) {
+        return where.expression(id, page, currentId);
+    }
+
+    public OrderSpecifier<String> order (StringPath id) {
+        return isAsc() ? id.asc() : id.desc();
+    }
+
+    public <N extends Number & Comparable<?>> OrderSpecifier<N> order (NumberPath<N> id) {
+        return isAsc() ? id.asc() : id.desc();
+    }
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/library/querydsl/reader/expression/OrderExpression.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/library/querydsl/reader/expression/OrderExpression.java
@@ -1,0 +1,10 @@
+package gwangju.ssafy.backend.global.infra.batch.library.querydsl.reader.expression;
+
+/**
+ * Created by jojoldu@gmail.com on 23/01/2020
+ * Blog : http://jojoldu.tistory.com
+ * Github : http://github.com/jojoldu
+ */
+public enum OrderExpression {
+    ASC, DESC
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/library/querydsl/reader/expression/WhereExpression.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/library/querydsl/reader/expression/WhereExpression.java
@@ -1,0 +1,41 @@
+package gwangju.ssafy.backend.global.infra.batch.library.querydsl.reader.expression;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.NumberPath;
+import com.querydsl.core.types.dsl.StringPath;
+
+/**
+ * Created by jojoldu@gmail.com on 23/01/2020
+ * Blog : http://jojoldu.tistory.com
+ * Github : http://github.com/jojoldu
+ */
+
+/**
+ * 첫페이지 조회시에는 >=, <=
+ * 두번째 페이지부터는 >, <
+ */
+public enum WhereExpression {
+    GT(
+            (id, page, currentId) -> page == 0? id.goe(currentId): id.gt(currentId),
+            (id, page, currentId) -> page == 0? id.goe(currentId): id.gt(currentId)),
+    LT(
+            (id, page, currentId) -> page == 0? id.loe(currentId): id.lt(currentId),
+            (id, page, currentId) -> page == 0? id.loe(currentId): id.lt(currentId)
+    );
+
+    private final WhereStringFunction string;
+    private final WhereNumberFunction number;
+
+    WhereExpression(WhereStringFunction string, WhereNumberFunction number) {
+        this.string = string;
+        this.number = number;
+    }
+
+    public BooleanExpression expression (StringPath id, int page, String currentId) {
+        return this.string.apply(id, page, currentId);
+    }
+
+    public <N extends Number & Comparable<?>>BooleanExpression expression (NumberPath<N> id, int page, N currentId) {
+        return this.number.apply(id, page, currentId);
+    }
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/library/querydsl/reader/expression/WhereNumberFunction.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/library/querydsl/reader/expression/WhereNumberFunction.java
@@ -1,0 +1,16 @@
+package gwangju.ssafy.backend.global.infra.batch.library.querydsl.reader.expression;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.NumberPath;
+
+/**
+ * Created by jojoldu@gmail.com on 23/01/2020
+ * Blog : http://jojoldu.tistory.com
+ * Github : http://github.com/jojoldu
+ */
+@FunctionalInterface
+public interface WhereNumberFunction<N extends Number & Comparable<?>> {
+
+    BooleanExpression apply(NumberPath<N> id, int page, N currentId);
+
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/library/querydsl/reader/expression/WhereStringFunction.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/library/querydsl/reader/expression/WhereStringFunction.java
@@ -1,0 +1,16 @@
+package gwangju.ssafy.backend.global.infra.batch.library.querydsl.reader.expression;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.StringPath;
+
+/**
+ * Created by jojoldu@gmail.com on 23/01/2020
+ * Blog : http://jojoldu.tistory.com
+ * Github : http://github.com/jojoldu
+ */
+@FunctionalInterface
+public interface WhereStringFunction {
+
+    BooleanExpression apply(StringPath id, int page, String currentId);
+
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/library/querydsl/reader/options/QuerydslNoOffsetNumberOptions.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/library/querydsl/reader/options/QuerydslNoOffsetNumberOptions.java
@@ -1,0 +1,110 @@
+package gwangju.ssafy.backend.global.infra.batch.library.querydsl.reader.options;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.NumberPath;
+import com.querydsl.jpa.impl.JPAQuery;
+import gwangju.ssafy.backend.global.infra.batch.library.querydsl.reader.expression.Expression;
+import jakarta.annotation.Nonnull;
+
+
+public class QuerydslNoOffsetNumberOptions<T, N extends Number & Comparable<?>> extends
+	QuerydslNoOffsetOptions<T> {
+
+    private N currentId;
+    private N lastId;
+
+    private final NumberPath<N> field;
+
+    public QuerydslNoOffsetNumberOptions(@Nonnull NumberPath<N> field,
+                                         @Nonnull Expression expression) {
+        super(field, expression);
+        this.field = field;
+    }
+
+    public N getCurrentId() {
+        return currentId;
+    }
+
+    public N getLastId() {
+        return lastId;
+    }
+
+    @Override
+    public void initKeys(JPAQuery<T> query, int page) {
+        if(page == 0) {
+            initFirstId(query);
+            initLastId(query);
+
+            if (logger.isDebugEnabled()) {
+                logger.debug("First Key= "+currentId+", Last Key= "+ lastId);
+            }
+        }
+    }
+
+    @Override
+    protected void initFirstId(JPAQuery<T> query) {
+        JPAQuery<T> clone = query.clone();
+        boolean isGroupByQuery = isGroupByQuery(clone);
+
+        if(isGroupByQuery) {
+            currentId = clone
+                    .select(field)
+                    .orderBy(expression.isAsc()? field.asc() : field.desc())
+                    .fetchFirst();
+        } else {
+            currentId = clone
+                    .select(expression.isAsc()? field.min(): field.max())
+                    .fetchFirst();
+        }
+
+    }
+
+    @Override
+    protected void initLastId(JPAQuery<T> query) {
+        JPAQuery<T> clone = query.clone();
+        boolean isGroupByQuery = isGroupByQuery(clone);
+
+        if(isGroupByQuery) {
+            lastId = clone
+                    .select(field)
+                    .orderBy(expression.isAsc()? field.desc() : field.asc())
+                    .fetchFirst();
+        } else {
+            lastId = clone
+                    .select(expression.isAsc()? field.max(): field.min())
+                    .fetchFirst();
+        }
+    }
+
+    @Override
+    public JPAQuery<T> createQuery(JPAQuery<T> query, int page) {
+        if(currentId == null) {
+            return query;
+        }
+
+        return query
+                .where(whereExpression(page))
+                .orderBy(orderExpression());
+    }
+
+    private BooleanExpression whereExpression(int page) {
+        return expression.where(field, page, currentId)
+                .and(expression.isAsc()? field.loe(lastId) : field.goe(lastId));
+    }
+
+    private OrderSpecifier<N> orderExpression() {
+        return expression.order(field);
+    }
+
+    @Override
+    public void resetCurrentId(T item) {
+        //noinspection unchecked
+        currentId = (N) getFiledValue(item);
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("Current Select Key= " + currentId);
+        }
+    }
+
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/library/querydsl/reader/options/QuerydslNoOffsetOptions.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/library/querydsl/reader/options/QuerydslNoOffsetOptions.java
@@ -1,0 +1,64 @@
+package gwangju.ssafy.backend.global.infra.batch.library.querydsl.reader.options;
+
+import com.querydsl.core.types.Path;
+import com.querydsl.jpa.impl.JPAQuery;
+import gwangju.ssafy.backend.global.infra.batch.library.querydsl.reader.expression.Expression;
+import jakarta.annotation.Nonnull;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+public abstract class QuerydslNoOffsetOptions<T> {
+    protected Log logger = LogFactory.getLog(getClass());
+
+    protected final String fieldName;
+    protected final Expression expression;
+
+    public QuerydslNoOffsetOptions(@Nonnull Path field,
+                                   @Nonnull Expression expression) {
+        String[] qField = field.toString().split("\\.");
+        this.fieldName = qField[qField.length-1];
+        this.expression = expression;
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("fieldName= " + fieldName);
+
+        }
+    }
+
+
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    public abstract void initKeys(JPAQuery<T> query, int page);
+
+    protected abstract void initFirstId(JPAQuery<T> query);
+    protected abstract void initLastId(JPAQuery<T> query);
+
+    public abstract JPAQuery<T> createQuery(JPAQuery<T> query, int page);
+
+    public abstract void resetCurrentId(T item);
+
+    protected Object getFiledValue(T item) {
+        try {
+            Field field = item.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            return field.get(item);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            logger.error("Not Found or Not Access Field= " + fieldName, e);
+            throw new IllegalArgumentException("Not Found or Not Access Field");
+        }
+    }
+
+    public boolean isGroupByQuery(JPAQuery<T> query) {
+        return isGroupByQuery(query.toString());
+    }
+
+    public boolean isGroupByQuery(String sql) {
+        return sql.contains("group by");
+
+    }
+
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/library/querydsl/reader/options/QuerydslNoOffsetStringOptions.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/library/querydsl/reader/options/QuerydslNoOffsetStringOptions.java
@@ -1,0 +1,106 @@
+package gwangju.ssafy.backend.global.infra.batch.library.querydsl.reader.options;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.StringPath;
+import com.querydsl.jpa.impl.JPAQuery;
+import gwangju.ssafy.backend.global.infra.batch.library.querydsl.reader.expression.Expression;
+import jakarta.annotation.Nonnull;
+
+
+public class QuerydslNoOffsetStringOptions<T> extends QuerydslNoOffsetOptions<T> {
+
+    private String currentId;
+    private String lastId;
+
+    private final StringPath field;
+
+    public QuerydslNoOffsetStringOptions(@Nonnull StringPath field,
+                                         @Nonnull Expression expression) {
+        super(field, expression);
+        this.field = field;
+    }
+
+    public String getCurrentId() {
+        return currentId;
+    }
+
+    public String getLastId() {
+        return lastId;
+    }
+
+    @Override
+    public void initKeys(JPAQuery<T> query, int page) {
+        if(page == 0) {
+            initFirstId(query);
+            initLastId(query);
+
+            if (logger.isDebugEnabled()) {
+                logger.debug("First Key= "+currentId+", Last Key= "+ lastId);
+            }
+        }
+    }
+
+    @Override
+    protected void initFirstId(JPAQuery<T> query) {
+        JPAQuery<T> clone = query.clone();
+        boolean isGroupByQuery = isGroupByQuery(clone);
+
+        if(isGroupByQuery) {
+            currentId = clone
+                    .select(field)
+                    .orderBy(expression.isAsc()? field.asc() : field.desc())
+                    .fetchFirst();
+        } else {
+            currentId = clone
+                    .select(expression.isAsc()? field.min(): field.max())
+                    .fetchFirst();
+        }
+
+    }
+
+    @Override
+    protected void initLastId(JPAQuery<T> query) {
+        JPAQuery<T> clone = query.clone();
+        boolean isGroupByQuery = isGroupByQuery(clone);
+
+        if(isGroupByQuery) {
+            lastId = clone
+                    .select(field)
+                    .orderBy(expression.isAsc()? field.desc() : field.asc())
+                    .fetchFirst();
+        } else {
+            lastId = clone
+                    .select(expression.isAsc()? field.max(): field.min())
+                    .fetchFirst();
+        }
+    }
+
+    @Override
+    public JPAQuery<T> createQuery(JPAQuery<T> query, int page) {
+        if (currentId == null) {
+            return query;
+        }
+
+        return query
+                .where(whereExpression(page))
+                .orderBy(orderExpression());
+    }
+
+    private BooleanExpression whereExpression(int page) {
+        return expression.where(field, page, currentId)
+                .and(expression.isAsc()? field.loe(lastId) : field.goe(lastId));
+    }
+
+    private OrderSpecifier<String> orderExpression() {
+        return expression.order(field);
+    }
+
+    @Override
+    public void resetCurrentId(T item) {
+        currentId = (String) getFiledValue(item);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Current Select Key= " + currentId);
+        }
+    }
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/params/DailyTransactionStatisticsParam.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/params/DailyTransactionStatisticsParam.java
@@ -1,0 +1,23 @@
+package gwangju.ssafy.backend.global.infra.batch.params;
+
+
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.batch.core.configuration.annotation.JobScope;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@JobScope
+@Component
+public class DailyTransactionStatisticsParam {
+
+	@Value("#{jobParameters[startDate]}")
+	private LocalDate startDate;
+	@Value("#{jobParameters[endDate]}")
+	private LocalDate endDate;
+
+
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/scheduler/DailyTransactionStatisticsScheduler.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/scheduler/DailyTransactionStatisticsScheduler.java
@@ -1,0 +1,32 @@
+package gwangju.ssafy.backend.global.infra.batch.scheduler;
+
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class DailyTransactionStatisticsScheduler {
+
+	private final JobLauncher jobLauncher;
+	private final Job dailyTransactionStatisticsJob;
+
+	@Scheduled(cron = "0 0 3 * * *")
+	public void runDailyTransactionStatistics()
+		throws Exception {
+
+		LocalDate now = LocalDate.now();
+		jobLauncher.run(dailyTransactionStatisticsJob, new JobParametersBuilder()
+			.addLocalDate("startDate", now.minusDays(1))
+			.addLocalDate("endDate", now)
+			.toJobParameters());
+	}
+
+
+}


### PR DESCRIPTION
**개요**

- #74 
- 매일 거래내역 통계 배치 구현

**타입**

- [x]  feat : 새로운 기능 추가


**작업 사항**
- 오전 3시에 전날 그룹계좌에서 발생한 거래내역을 통계내서 DB에 저장하는 배치 작업을 구현했습니다.