### PR TITLE
feat: 그룹 계좌 거래내역 월간 통계 구현

### DIFF
--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/entity/MonthlyTransactionStatistics.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/entity/MonthlyTransactionStatistics.java
@@ -1,0 +1,42 @@
+package gwangju.ssafy.backend.domain.transaction.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class MonthlyTransactionStatistics {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+
+	@JoinColumn
+	private Long groupAccountId;
+
+	@Column
+	private Long withdrawal;
+
+	@Column
+	private Long deposit;
+
+	@Column(name = "years")
+	private Integer year;
+
+	@Column(name = "months")
+	private Integer month;
+
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/repository/DailyTransactionStatisticsRepository.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/repository/DailyTransactionStatisticsRepository.java
@@ -1,0 +1,10 @@
+package gwangju.ssafy.backend.domain.transaction.repository;
+
+import gwangju.ssafy.backend.domain.transaction.entity.DailyTransactionStatistics;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DailyTransactionStatisticsRepository extends JpaRepository<DailyTransactionStatistics,Long> {
+
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/dto/DailyTransactionStatisticsBatchDto.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/dto/DailyTransactionStatisticsBatchDto.java
@@ -13,21 +13,20 @@ import lombok.Setter;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class TransactionStatisticsBatchDto {
+public class DailyTransactionStatisticsBatchDto {
 	// groupAccountId
 	private Long id;
 	private Long totalWithdrawal;
 	private Long totalDeposit;
-	private LocalDate startDate;
-	private LocalDate endDate;
+	private LocalDate date;
 
 	public DailyTransactionStatistics toEntity() {
 		return DailyTransactionStatistics.builder()
 			.groupAccountId(this.id)
 			.withdrawal(this.totalWithdrawal)
 			.deposit(this.totalDeposit)
-			.date(this.startDate)
-			.dayOfWeek(this.startDate.getDayOfWeek().name())
+			.date(this.date)
+			.dayOfWeek(this.date.getDayOfWeek().name())
 			.build();
 	}
 }

--- a/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/dto/MonthlyTransactionStatisticsBatchDto.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/dto/MonthlyTransactionStatisticsBatchDto.java
@@ -1,0 +1,33 @@
+package gwangju.ssafy.backend.global.infra.batch.dto;
+
+import gwangju.ssafy.backend.domain.transaction.entity.MonthlyTransactionStatistics;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class MonthlyTransactionStatisticsBatchDto {
+	// groupAccountId
+	private Long groupAccountId;
+	private Long totalWithdrawal;
+	private Long totalDeposit;
+	private Integer year;
+	private Integer month;
+
+	public MonthlyTransactionStatistics toEntity() {
+		return MonthlyTransactionStatistics.builder()
+			.groupAccountId(this.groupAccountId)
+			.withdrawal(this.totalWithdrawal)
+			.deposit(this.totalDeposit)
+			.year(this.year)
+			.month(this.month)
+			.build();
+	}
+
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/jobs/MonthlyTransactionStatisticsJobConfig.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/jobs/MonthlyTransactionStatisticsJobConfig.java
@@ -1,0 +1,97 @@
+package gwangju.ssafy.backend.global.infra.batch.jobs;
+
+import static gwangju.ssafy.backend.domain.transaction.entity.QDailyTransactionStatistics.dailyTransactionStatistics;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
+import gwangju.ssafy.backend.global.infra.batch.dto.MonthlyTransactionStatisticsBatchDto;
+import gwangju.ssafy.backend.global.infra.batch.library.querydsl.reader.QuerydslNoOffsetIdPagingItemReader;
+import gwangju.ssafy.backend.global.infra.batch.library.querydsl.reader.expression.Expression;
+import gwangju.ssafy.backend.global.infra.batch.library.querydsl.reader.options.QuerydslNoOffsetNumberOptions;
+import gwangju.ssafy.backend.global.infra.batch.params.MonthlyTransactionStatisticsParam;
+import jakarta.persistence.EntityManagerFactory;
+import java.time.LocalDate;
+import javax.sql.DataSource;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobScope;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.database.JdbcBatchItemWriter;
+import org.springframework.batch.item.database.builder.JdbcBatchItemWriterBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class MonthlyTransactionStatisticsJobConfig {
+
+	private static final int CHUNK_SIZE = 100;
+	private final EntityManagerFactory emf;
+	private final MonthlyTransactionStatisticsParam jobParam;
+	private final DataSource dataSource;
+
+
+	@Bean
+	public Job monthlyTransactionStatisticsJob(JobRepository jobRepository,
+		PlatformTransactionManager platformTransactionManager) {
+		return new JobBuilder("monthly_transaction_statistics", jobRepository)
+			.start(monthlyTransactionStatisticsStep(jobRepository, platformTransactionManager))
+			.build();
+	}
+
+	@Bean
+	@JobScope
+	public Step monthlyTransactionStatisticsStep(JobRepository jobRepository,
+		PlatformTransactionManager transactionManager) {
+		return new StepBuilder("monthly_transaction_statistics", jobRepository)
+			.<MonthlyTransactionStatisticsBatchDto, MonthlyTransactionStatisticsBatchDto>chunk(
+				CHUNK_SIZE, transactionManager)
+			.reader(monthlyTransactionStatisticsReader())
+			.writer(monthlyTransactionStatisticsWriter())
+			.build();
+	}
+
+	@Bean
+	@JobScope
+	public QuerydslNoOffsetIdPagingItemReader<MonthlyTransactionStatisticsBatchDto, Long> monthlyTransactionStatisticsReader() {
+		QuerydslNoOffsetNumberOptions<MonthlyTransactionStatisticsBatchDto, Long> options =
+			new QuerydslNoOffsetNumberOptions<>(dailyTransactionStatistics.groupAccountId,
+				Expression.ASC);
+
+		LocalDate start = LocalDate.of(jobParam.getYear(), jobParam.getMonth(), 1);
+		LocalDate end = LocalDate.of(jobParam.getYear(), jobParam.getMonth(), 1).plusMonths(1);
+
+		return new QuerydslNoOffsetIdPagingItemReader<>(emf, CHUNK_SIZE, options,
+			queryFactory -> queryFactory
+				.select(Projections.fields(MonthlyTransactionStatisticsBatchDto.class,
+					dailyTransactionStatistics.groupAccountId.as("groupAccountId"),
+					dailyTransactionStatistics.withdrawal.sum().as("totalWithdrawal"),
+					dailyTransactionStatistics.deposit.sum().as("totalDeposit"),
+					Expressions.asDate(jobParam.getYear()).as("year"),
+					Expressions.asDate(jobParam.getMonth()).as("month")))
+				.from(dailyTransactionStatistics)
+				.where(dailyTransactionStatistics.date.goe(start),
+					dailyTransactionStatistics.date.lt(end))
+				.groupBy(dailyTransactionStatistics.groupAccountId)
+		);
+	}
+
+	@Bean
+	@StepScope
+	public JdbcBatchItemWriter<MonthlyTransactionStatisticsBatchDto> monthlyTransactionStatisticsWriter() {
+		return new JdbcBatchItemWriterBuilder<MonthlyTransactionStatisticsBatchDto>()
+			.dataSource(dataSource)
+			.sql(
+				"insert into monthly_transaction_statistics(group_account_id, withdrawal, deposit, years, months) values(:groupAccountId, :totalWithdrawal, :totalDeposit, :year, :month)")
+			.beanMapped()
+			.build();
+	}
+
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/params/MonthlyTransactionStatisticsParam.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/params/MonthlyTransactionStatisticsParam.java
@@ -1,0 +1,23 @@
+package gwangju.ssafy.backend.global.infra.batch.params;
+
+
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.batch.core.configuration.annotation.JobScope;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@JobScope
+@Component
+public class MonthlyTransactionStatisticsParam {
+
+	@Value("#{jobParameters[year]}")
+	private Long year;
+	@Value("#{jobParameters[month]}")
+	private Long month;
+
+
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/params/MonthlyTransactionStatisticsParam.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/params/MonthlyTransactionStatisticsParam.java
@@ -15,9 +15,9 @@ import org.springframework.stereotype.Component;
 public class MonthlyTransactionStatisticsParam {
 
 	@Value("#{jobParameters[year]}")
-	private Long year;
+	private Integer year;
 	@Value("#{jobParameters[month]}")
-	private Long month;
+	private Integer month;
 
 
 }

--- a/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/scheduler/MonthlyTransactionStatisticsScheduler.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/global/infra/batch/scheduler/MonthlyTransactionStatisticsScheduler.java
@@ -1,0 +1,34 @@
+package gwangju.ssafy.backend.global.infra.batch.scheduler;
+
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class MonthlyTransactionStatisticsScheduler {
+
+	private final JobLauncher jobLauncher;
+	private final Job monthlyTransactionStatisticsJob;
+
+	@Scheduled(cron = "0 0 5 1 1/1 ?")
+	public void runDailyTransactionStatistics()
+		throws Exception {
+
+		LocalDate now = LocalDate.now();
+		LocalDate date = LocalDate.of(now.getYear(), now.getMonth(), 1).minusMonths(1);
+
+		jobLauncher.run(monthlyTransactionStatisticsJob, new JobParametersBuilder()
+			.addLong("year", (long)date.getYear())
+			.addLong("month",(long) date.getMonthValue())
+			.toJobParameters());
+	}
+
+
+}


### PR DESCRIPTION
**개요**

- #74 
-그룹 계좌 거래내역 월간 통계 구현

**타입**

- [x]  feat : 새로운 기능 추가


**작업 사항**
- 매월 1일 오전 5시에 이전 달의 거래내역을 통계내서 DB에 저장하는 배치 작업을 구현했습니다.