### PR TITLE
feat: 거래내역 조회API에 날짜 조회 기능 추가

### DIFF
--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/dto/GetTransactionsRequest.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/dto/GetTransactionsRequest.java
@@ -1,9 +1,14 @@
 package gwangju.ssafy.backend.domain.transaction.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Shape;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
-import java.awt.print.Pageable;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -25,5 +30,13 @@ public class GetTransactionsRequest {
 	@Max(100)
 	private Long limit;
 	private long pageNumber;
+
+	@JsonDeserialize(using = LocalDateDeserializer.class)
+	@JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd")
+	private LocalDate startDate;
+
+	@JsonDeserialize(using = LocalDateDeserializer.class)
+	@JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd")
+	private LocalDate endDate;
 
 }

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/repository/QueryDslTransactionRepository.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/repository/QueryDslTransactionRepository.java
@@ -1,11 +1,13 @@
 package gwangju.ssafy.backend.domain.transaction.repository;
 
 import gwangju.ssafy.backend.domain.transaction.dto.TransactionInfo;
+import java.time.LocalDate;
 import java.util.List;
 
 public interface QueryDslTransactionRepository {
 
 	// 그룹 필터링 및 페이징 조회
-	List<TransactionInfo> findAllByGroupAccountId(Long accountId, Long limit, Long pageNum);
+	List<TransactionInfo> findAllByGroupAccountId(Long accountId, Long limit, Long pageNum,
+		LocalDate start, LocalDate end);
 
 }

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/repository/impl/QueryDslTransactionRepositoryImpl.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/repository/impl/QueryDslTransactionRepositoryImpl.java
@@ -1,13 +1,17 @@
 package gwangju.ssafy.backend.domain.transaction.repository.impl;
 
+import static gwangju.ssafy.backend.domain.group.entity.QGroup.group;
 import static gwangju.ssafy.backend.domain.transaction.entity.QGroupAccount.groupAccount;
 import static gwangju.ssafy.backend.domain.transaction.entity.QTransaction.transaction;
 
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import gwangju.ssafy.backend.domain.transaction.dto.GetTransactionsRequest;
+import gwangju.ssafy.backend.domain.group.entity.enums.GroupCategory;
 import gwangju.ssafy.backend.domain.transaction.dto.TransactionInfo;
 import gwangju.ssafy.backend.domain.transaction.repository.QueryDslTransactionRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -19,7 +23,9 @@ public class QueryDslTransactionRepositoryImpl implements QueryDslTransactionRep
 	private final JPAQueryFactory jpaQueryFactory;
 
 	@Override
-	public List<TransactionInfo> findAllByGroupAccountId(Long accountId, Long limit, Long pageNum) {
+	public List<TransactionInfo> findAllByGroupAccountId(Long accountId, Long limit, Long pageNum,
+		LocalDate start, LocalDate end) {
+
 		return jpaQueryFactory.select(Projections.fields(TransactionInfo.class,
 				transaction.id.as("transactionId"),
 				groupAccount.id.as("groupAccountId"),
@@ -32,14 +38,25 @@ public class QueryDslTransactionRepositoryImpl implements QueryDslTransactionRep
 				transaction.category.as("category"),
 				transaction.branch.as("branch"),
 				transaction.note.as("note")
-				))
+			))
 			.from(transaction)
 			.innerJoin(transaction.groupAccount, groupAccount)
-			.where(groupAccount.id.eq(accountId))
+			.where(groupAccount.id.eq(accountId), filterStartDate(start), filterEndDate(end))
 			.orderBy(transaction.date.desc())
 			.limit(limit)
 			.offset(pageNum * limit)
 			.fetch();
 	}
 
+	private BooleanExpression filterStartDate(LocalDate start) {
+		return start == null ? null
+			: transaction.date.goe(LocalDateTime.of(start.getYear(), start.getMonth(),
+				start.getDayOfMonth(), 0, 0));
+	}
+
+	private BooleanExpression filterEndDate(LocalDate end) {
+		return end == null ? null
+			: transaction.date.loe(LocalDateTime.of(end.getYear(), end.getMonth(),
+				end.getDayOfMonth(), 0, 0).plusDays(1));
+	}
 }

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/service/impl/TransactionServiceImpl.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/transaction/service/impl/TransactionServiceImpl.java
@@ -62,6 +62,6 @@ public class TransactionServiceImpl implements TransactionService {
 			.orElseThrow(() -> new RuntimeException("그룹원이 아님"));
 
 		return transactionRepository.findAllByGroupAccountId(account.getId(), request.getLimit(),
-			request.getPageNumber());
+			request.getPageNumber(), request.getStartDate(), request.getEndDate());
 	}
 }


### PR DESCRIPTION
**개요**

- #74 
-거래내역 조회API에 날짜 조회 기능 추가

**타입**

- [x]  feat : 새로운 기능 추가


**작업 사항**
- 주간 거래내역 통계 대신에 사용할 거래내역 조회 API에 날짜 조회도 가능하도록 추가하였습니다.