### PR TITLE
fix: AccessToken 복호화시 claims에 null 처리 되는 경우 처리

### DIFF
--- a/Backend/src/main/java/gwangju/ssafy/backend/global/component/jwt/JwtParser.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/global/component/jwt/JwtParser.java
@@ -5,6 +5,8 @@ import gwangju.ssafy.backend.global.component.jwt.security.JwtAuthenticationFilt
 import gwangju.ssafy.backend.global.exception.ErrorCode;
 import gwangju.ssafy.backend.global.exception.TokenException;
 import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.DecodingException;
+import io.jsonwebtoken.security.SignatureException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,14 +28,16 @@ public class JwtParser {
         Claims claims = null;
 
         try {
+            log.info(token);
+            log.info(sercretKey.toString());
             claims = Jwts.parserBuilder()
                     .setSigningKey(sercretKey)
                     .build()
                     .parseClaimsJws(token).getBody();
-            log.info(token);
+            log.info(claims.toString());
 
         } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException | UnsupportedJwtException |
-                 IllegalArgumentException e) {
+                 IllegalArgumentException | DecodingException e) {
 //            log.info("잘못된 JWT 서명입니다. (유효하지 않은 인증 토큰입니다)");
             throw new TokenException(ErrorCode.INVALID_TOKEN, e);
         } catch (ExpiredJwtException e) {
@@ -61,4 +65,5 @@ public class JwtParser {
         // AccessToken 만료 안된 경우
         return claims;
     }
+
 }

--- a/Backend/src/main/java/gwangju/ssafy/backend/global/component/jwt/security/JwtAuthenticationFilter.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/global/component/jwt/security/JwtAuthenticationFilter.java
@@ -1,9 +1,11 @@
 package gwangju.ssafy.backend.global.component.jwt.security;
 
 import gwangju.ssafy.backend.domain.user.dto.LoginActiveUserDto;
+import gwangju.ssafy.backend.global.component.jwt.dto.TokenUserInfoDto;
 import gwangju.ssafy.backend.global.component.jwt.service.JwtService;
 import gwangju.ssafy.backend.global.exception.ErrorCode;
 import gwangju.ssafy.backend.global.exception.TokenException;
+import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -58,9 +60,26 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     public void authenticate(HttpServletRequest request, String token) {
         if(StringUtils.hasText(token)) {
-            LoginActiveUserDto loginActiveUserDto = LoginActiveUserDto.from(jwtService.parseAccessToken(token));
-            log.info(loginActiveUserDto.getUserEmail());
-            saveLoginUserInSecurityContext(loginActiveUserDto);
+            log.info(request.getHeader(AUTHORIZATION_HEADER).toString());
+            TokenUserInfoDto tokenUserInfoDto = jwtService.parseAccessToken(token);
+            try {
+                LoginActiveUserDto loginActiveUserDto = LoginActiveUserDto.from(tokenUserInfoDto);
+                log.info(loginActiveUserDto.getUserEmail());
+                saveLoginUserInSecurityContext(loginActiveUserDto);
+            }
+            catch(RuntimeException e){
+                throw new TokenException(ErrorCode.INVALID_TOKEN, e);
+            }
+
+//            if(tokenUserInfoDto != null) {
+//                LoginActiveUserDto loginActiveUserDto = LoginActiveUserDto.from(tokenUserInfoDto);
+//                log.info(loginActiveUserDto.getUserEmail());
+//                saveLoginUserInSecurityContext(loginActiveUserDto);
+//            }
+//            else {
+//
+//            }
+
 //            SecurityContextHolder.clearContext();
         }
     }

--- a/Backend/src/main/java/gwangju/ssafy/backend/global/component/jwt/service/JwtServiceImpl.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/global/component/jwt/service/JwtServiceImpl.java
@@ -59,6 +59,7 @@ public class JwtServiceImpl implements JwtService {
     // refresh 토큰을 통한 accessToken 재발급
     @Override
     public TokenDto refreshToken(@NonNull String refreshToken) {
+
         Claims claims = jwtParser.parseToken(refreshToken, jwtUtils.getEncodedKey());
 
         String savedToken = refreshRepository.find(claims.get(KEY_EMAIL, String.class))
@@ -80,9 +81,13 @@ public class JwtServiceImpl implements JwtService {
     // access 토큰 파싱
     @Override
     public TokenUserInfoDto parseAccessToken(@NonNull String accessToken) {
-        return TokenUserInfoDto.from(
-                jwtParser.parseToken(accessToken, jwtUtils.getEncodedKey())
-        );
+        Claims claims = jwtParser.parseToken(accessToken, jwtUtils.getEncodedKey());
+
+        if(claims == null) {
+            return null;
+        }
+
+        return TokenUserInfoDto.from(claims);
     }
 
     // redisTemplate을 통해 refresh 토큰 삭제(블랙리스트 추가)


### PR DESCRIPTION
- #105 
- jwt token값 복호화시 claims가 null 처리가 되는 경우가 있어 유저정보로 변환할 시 null pointer exception이 발생하는데 이 경우를 처리하였습니다.

**타입**
- [x]  fix : 핫픽스 

정상 실행 확인 하였습니다.