### PR TITLE
feat: 그룹 내 가입 신청 처리 조회, 수락, 거절 기능 구현

### DIFF
--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/group/controller/GroupSignupController.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/group/controller/GroupSignupController.java
@@ -1,0 +1,43 @@
+package gwangju.ssafy.backend.domain.group.controller;
+
+import gwangju.ssafy.backend.domain.group.dto.DeleteGroupSignInfoRequest;
+import gwangju.ssafy.backend.domain.group.dto.GetGroupSignupInfo;
+import gwangju.ssafy.backend.domain.group.dto.GetMemberRoleResponse;
+import gwangju.ssafy.backend.domain.group.dto.GroupSignupInfo;
+import gwangju.ssafy.backend.domain.group.service.GroupSignupService;
+import gwangju.ssafy.backend.global.common.dto.Message;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RequestMapping("/group/signup")
+@RestController
+public class GroupSignupController {
+    private final GroupSignupService groupSignupService;
+
+    // 해당 그룹 가입 신청 대기자들 조회
+    @GetMapping("/list")
+    public ResponseEntity<Message<List<GroupSignupInfo>>> searchAllGroupSignup() {
+        List<GroupSignupInfo> groupSignupInfoList = groupSignupService.searchAllGroupSignup();
+        return ResponseEntity.ok().body(Message.success(groupSignupInfoList));
+    }
+
+    // 해당 그룹 가입 신청 유저 거절 처리
+    @DeleteMapping("/reject/{groupSignupId}")
+    public ResponseEntity<Message<GroupSignupInfo>> rejectSignup(@RequestBody DeleteGroupSignInfoRequest request,
+                                                                      @PathVariable("groupSignupId") Long groupSignupId) {
+        request.setGroupSignUpId(groupSignupId);
+        return ResponseEntity.ok().body(Message.success(groupSignupService.rejectSignup(request)));
+    }
+
+    // 해당 그룹 가입 신청 유저 수락 처리
+    @PutMapping("/approve/{groupSignupId}")
+    public ResponseEntity<Message<GroupSignupInfo>> approveSignup(@RequestBody GetGroupSignupInfo request,
+                                                                  @PathVariable("groupSignupId") Long groupSignupId) {
+        request.setGroupSignUpId(groupSignupId);
+        return ResponseEntity.ok().body(Message.success(groupSignupService.ApproveGroupSignUp(request)));
+    }
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/group/dto/DeleteGroupSignInfoRequest.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/group/dto/DeleteGroupSignInfoRequest.java
@@ -1,0 +1,13 @@
+package gwangju.ssafy.backend.domain.group.dto;
+
+import lombok.*;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+@Setter
+public class DeleteGroupSignInfoRequest {
+    private Long groupSignUpId;
+    private Long userId;
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/group/dto/GetGroupSignupInfo.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/group/dto/GetGroupSignupInfo.java
@@ -1,0 +1,13 @@
+package gwangju.ssafy.backend.domain.group.dto;
+
+import lombok.*;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+@Setter
+public class GetGroupSignupInfo {
+    private Long groupSignUpId;
+    private Long userId;
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/group/dto/GroupSignupInfo.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/group/dto/GroupSignupInfo.java
@@ -1,0 +1,34 @@
+package gwangju.ssafy.backend.domain.group.dto;
+
+import gwangju.ssafy.backend.domain.group.entity.GroupSignup;
+import gwangju.ssafy.backend.domain.user.entity.enums.UserRole;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class GroupSignupInfo {
+    private Long groupSingupId;
+    private Long groupId;
+    private String userEmail;
+    private String userName;
+    private String userNickname;
+    private String userImgUrl;
+    private UserRole role;
+    private boolean signupStatus;
+
+    public void convert(GroupSignup groupSignup) {
+        this.groupSingupId = groupSignup.getId();
+        this.groupId = groupSignup.getGroup().getId();
+        this.userEmail = groupSignup.getUser().getUserEmail();
+        this.userName = groupSignup.getUser().getUserName();
+        this.userNickname = groupSignup.getUser().getUserNickname();
+        this.userImgUrl = groupSignup.getUser().getUserImageUrl();
+        this.role = groupSignup.getUser().getRole();
+        this.signupStatus = groupSignup.isSignupStatus();
+    }
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/group/entity/GroupSignup.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/group/entity/GroupSignup.java
@@ -1,0 +1,37 @@
+package gwangju.ssafy.backend.domain.group.entity;
+
+import gwangju.ssafy.backend.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "group_signup")
+@Entity
+public class GroupSignup {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(nullable = false)
+    private Group group;
+
+    @Column
+    private boolean signupStatus;
+
+    // 승인 처리
+    public void signupApprove() {
+        this.signupStatus = true;
+    }
+
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/group/repository/GroupSignupRepository.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/group/repository/GroupSignupRepository.java
@@ -1,0 +1,12 @@
+package gwangju.ssafy.backend.domain.group.repository;
+
+import gwangju.ssafy.backend.domain.group.entity.GroupSignup;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface GroupSignupRepository extends JpaRepository<GroupSignup, Long> {
+    List<GroupSignup> findAllBySignupStatus(boolean status);
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/group/service/GroupSignupService.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/group/service/GroupSignupService.java
@@ -1,0 +1,19 @@
+package gwangju.ssafy.backend.domain.group.service;
+
+import gwangju.ssafy.backend.domain.group.dto.DeleteGroupSignInfoRequest;
+import gwangju.ssafy.backend.domain.group.dto.GroupSignupInfo;
+import gwangju.ssafy.backend.domain.group.dto.GetGroupSignupInfo;
+
+import java.util.List;
+
+public interface GroupSignupService {
+    // 그룹 가입에서 해당 그룹에 가입 신청 대기중인 리스트 가져오기
+    List<GroupSignupInfo> searchAllGroupSignup();
+
+    // 그룹에서 해당 유저 가입 거절
+    GroupSignupInfo rejectSignup(DeleteGroupSignInfoRequest request);
+
+    // 그룹 내 해당 가입 신청 수락
+    GroupSignupInfo ApproveGroupSignUp(GetGroupSignupInfo request);
+
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/domain/group/service/impl/GroupSignupServiceImpl.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/domain/group/service/impl/GroupSignupServiceImpl.java
@@ -1,0 +1,78 @@
+package gwangju.ssafy.backend.domain.group.service.impl;
+
+import gwangju.ssafy.backend.domain.group.dto.DeleteGroupSignInfoRequest;
+import gwangju.ssafy.backend.domain.group.dto.GroupSignupInfo;
+import gwangju.ssafy.backend.domain.group.dto.GetGroupSignupInfo;
+import gwangju.ssafy.backend.domain.group.entity.GroupMember;
+import gwangju.ssafy.backend.domain.group.entity.GroupSignup;
+import gwangju.ssafy.backend.domain.group.entity.enums.GroupMemberRole;
+import gwangju.ssafy.backend.domain.group.repository.GroupMemberRepository;
+import gwangju.ssafy.backend.domain.group.repository.GroupSignupRepository;
+import gwangju.ssafy.backend.domain.group.service.GroupSignupService;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class GroupSignupServiceImpl implements GroupSignupService {
+
+    private final GroupSignupRepository groupSignupRepository;
+
+    private final GroupMemberRepository groupMemberRepository;
+
+
+    // 해당 그룹에 가입 신청한 회원들 전체 조회
+    @Override
+    public List<GroupSignupInfo> searchAllGroupSignup() {
+        // 가입 요청 대기중인 사람들만 추출 (BysignupStatus)
+        List<GroupSignup> groupSignupList = groupSignupRepository.findAllBySignupStatus(false);
+        List<GroupSignupInfo> groupSignupInfoList = new ArrayList<>();
+        for (GroupSignup groupSignup : groupSignupList) {
+            GroupSignupInfo groupSignupInfo = new GroupSignupInfo();
+            groupSignupInfo.convert(groupSignup);
+            log.info(groupSignupInfo.getUserName());
+            groupSignupInfoList.add(groupSignupInfo);
+        }
+        return groupSignupInfoList;
+    }
+
+    // 해당 그룹에 가입 신청한 사람 가입 신청 거절
+    @Override
+    public GroupSignupInfo rejectSignup(DeleteGroupSignInfoRequest request) {
+        GroupSignup groupSignup = groupSignupRepository.findById(request.getGroupSignUpId())
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 가입 신청내역"));
+        groupSignupRepository.delete(groupSignup);
+        GroupSignupInfo groupSignupInfo = new GroupSignupInfo();
+        groupSignupInfo.convert(groupSignup);
+        return groupSignupInfo;
+    }
+
+
+    // 그룹 내 해당 가입 신청 수락
+    @Override
+    public GroupSignupInfo ApproveGroupSignUp(GetGroupSignupInfo request) {
+        GroupSignup groupSignup = groupSignupRepository.findById(request.getGroupSignUpId())
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 가입 신청내역"));
+        groupSignup.signupApprove();    // 해당 가입신청 가입 처리 (update)
+
+        GroupMember groupMember = GroupMember.builder()
+                .group(groupSignup.getGroup())
+                .user(groupSignup.getUser())
+                .role(GroupMemberRole.MEMBER)
+                .build();
+
+        groupMemberRepository.save(groupMember);    // 해당 가입신청한 유저정보 및 그룹 정보 그룹원(소속원) DB에 저장
+        GroupSignupInfo groupSignupInfo = new GroupSignupInfo();
+        groupSignupInfo.convert(groupSignup);
+        return groupSignupInfo;
+    }
+
+
+}

--- a/Backend/src/main/java/gwangju/ssafy/backend/global/config/TestConfig.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/global/config/TestConfig.java
@@ -1,0 +1,2 @@
+package gwangju.ssafy.backend.global.config;public class TestConfig {
+}


### PR DESCRIPTION
**개요**

- #103 
- 그룹(학생회/동아리) 멤버의 장이 유저의 가입 요청 대기중인 것들 조회해주는 기능 구현
- 그룹(학생회/동아리) 멤버의 장이 유저의 가입 요청을 거절하는 기능을 구현
- 그룹(학생회/동아리) 멤버의 장이 유저의 가입 요청을 수락하는 기능을 구현
- 그룹 가입 요청과 관련된 엔티티 추가

**타입**

- [x]  feat : 새로운 기능 추가

**작업 사항**
- 그룹 가입 요청 관련 리스트 조회 기능을 구현하였습니다.
- 그룹 가입 요청 관련 수락 기능을 구현하였습니다.
- 그룹 가입 요청 관련 거절 기능을 구현하였습니다.