### PR TITLE
feat: jwt 토큰에 대한 자격증명 및 권한 없이 접근 할 경우 response 에러 응답 간소화 기능 구현

### DIFF
--- a/Backend/src/main/java/gwangju/ssafy/backend/global/component/jwt/security/JwtAccessDeniedHandler.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/global/component/jwt/security/JwtAccessDeniedHandler.java
@@ -1,14 +1,19 @@
 package gwangju.ssafy.backend.global.component.jwt.security;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gwangju.ssafy.backend.global.common.dto.Message;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+
+import static gwangju.ssafy.backend.global.exception.ErrorCode.NOT_AUTHORITY_USER_API;
 
 /**
  * 권한 없이 접근시, 403 응답을 보여줌
@@ -21,6 +26,16 @@ public class JwtAccessDeniedHandler implements AccessDeniedHandler {
         // 권한 없이 접근시, 403 응답
         log.info("====================JwtAccessDeniedHandler=====================");
         log.info("권한 없이 접근한 경우");
-        response.sendError(HttpServletResponse.SC_FORBIDDEN);
+
+        setResponse(response);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        response.getWriter().write(objectMapper.writeValueAsString(Message.fail(null, NOT_AUTHORITY_USER_API.getErrorMessage())));
+    }
+
+    private void setResponse(HttpServletResponse response) {
+        response.setStatus(NOT_AUTHORITY_USER_API.getHttpStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("utf-8");
     }
 }

--- a/Backend/src/main/java/gwangju/ssafy/backend/global/component/jwt/security/JwtAuthenticationEntryPoint.java
+++ b/Backend/src/main/java/gwangju/ssafy/backend/global/component/jwt/security/JwtAuthenticationEntryPoint.java
@@ -1,7 +1,10 @@
 package gwangju.ssafy.backend.global.component.jwt.security;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gwangju.ssafy.backend.global.common.dto.Message;
 import jakarta.servlet.ServletException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
@@ -9,6 +12,8 @@ import org.springframework.stereotype.Component;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+
+import static gwangju.ssafy.backend.global.exception.ErrorCode.INVALID_TOKEN;
 
 /**
  * 자격 증명 없이 접근시, 401 응답을 보여줌
@@ -22,6 +27,16 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
         // 자격증명 없이 접근시, 401응답
         log.info("====================JwtAuthenticationEntryPoint=====================");
         log.info("자격 증명 없이 접근한 경우");
-        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+
+        setResponse(response);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        response.getWriter().write(objectMapper.writeValueAsString(Message.fail(null, INVALID_TOKEN.getErrorMessage())));
+    }
+
+    private void setResponse(HttpServletResponse response) {
+        response.setStatus(INVALID_TOKEN.getHttpStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("utf-8");
     }
 }


### PR DESCRIPTION
**개요**

- #119 
- jwt 토큰에 대한 자격증명 및 권한 없이 접근 할 경우 response 에러 응답 간소화 처리

**타입**

- [x]  feat : 새로운 기능 추가

**작업 사항**
- security config에서 jwt 토큰에 대한 자격증명 및 권한을 체크하여 체크가 안된 상태로 접근시 response 에러 응답을 길게 보내는게 아닌 간소화해서 보내도록 처리하였습니다.